### PR TITLE
fixes typo for title Bridge

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -524,7 +524,7 @@
           "path": "advanced/proxy-subscriptions"
         },
         {
-          "title": "Brige",
+          "title": "Bridge",
           "path": "advanced/bridge"
         },
         {


### PR DESCRIPTION
Simple fix for the typo Bridge in the directory.