### PR TITLE
Fix acl config field typo error

### DIFF
--- a/en_US/modules/internal_acl.md
+++ b/en_US/modules/internal_acl.md
@@ -64,7 +64,7 @@ The grammar rules of ʻacl.conf` are contained in the comments at the top. Those
 
 ​ * `{user, "dashboard"}`: indicates that the rule only takes effect for the user whose *Username (Username)* is "dashboard"
 
-​ * `{clientid, "dashboard"}`: indicates that the rule only takes effect for users whose *client ID (ClientId)* is "dashboard"
+​ * `{client, "dashboard"}`: indicates that the rule only takes effect for users whose *client ID (ClientId)* is "dashboard"
 
 ​ * `{ipaddr, "127.0.0.1"}`: indicates that the rule only takes effect for users whose source address is "127.0.0.1"
 

--- a/zh_CN/modules/internal_acl.md
+++ b/zh_CN/modules/internal_acl.md
@@ -66,7 +66,7 @@
 
 ​    * `{user, "dashboard"}`：表明规则仅对 *用户名 (Username)* 为 "dashboard" 的用户生效
 
-​    * `{clientid, "dashboard"}`：表明规则仅对 *客户端标识 (ClientId)* 为 "dashboard" 的用户生效
+​    * `{client, "dashboard"}`：表明规则仅对 *客户端标识 (ClientId)* 为 "dashboard" 的用户生效
 
 ​    * `{ipaddr, "127.0.0.1"}`：表明规则仅对 *源地址* 为 "127.0.0.1" 的用户生效
 


### PR DESCRIPTION
In acl.conf, clientid rules can't use `clientid` field name and emqx would report an error.
But `client` worked