### PR TITLE
fix：修改 延迟发布 状态默认为关闭状态

### DIFF
--- a/zh_CN/advanced/delay-publish.md
+++ b/zh_CN/advanced/delay-publish.md
@@ -33,4 +33,4 @@ $delayed/{DelayInterval}/{TopicName}
 - `$delayed/60/a/b`: 1 分钟后将 MQTT 消息发布到 `a/b`。
 - `$delayed/3600/$SYS/topic`: 1 小时后将 MQTT 消息发布到 `$SYS/topic`。
 
-延迟发布功能由 `emqx_mod_delayed` 内置模块提供，此功能默认开启，支持动态启停，请参见 [modules 命令](./cli.html#modules-%E5%91%BD%E4%BB%A4)。
+延迟发布功能由 `emqx_mod_delayed` 内置模块提供，此功能默认关闭，支持动态启停，可在【模块】选项中点击启用，请参见 [modules 命令](./cli.html#modules-%E5%91%BD%E4%BB%A4)。


### PR DESCRIPTION
实际中，延迟发布 模块是默认关闭的，启用需要手工打开