### PR TITLE
fix install card error

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -633,7 +633,7 @@
           "path": "tutorial/prometheus"
         },
         {
-          "title": "性能测试",
+          "title": "emqtt_bench 性能测试",
           "path": "tutorial/benchmark"
         }
       ]
@@ -1433,7 +1433,7 @@
           "path": "tutorial/prometheus"
         },
         {
-          "title": "Benchmark",
+          "title": "emqtt_bench Benchmark",
           "path": "tutorial/benchmark"
         }
       ]

--- a/en_US/tutorial/benchmark.md
+++ b/en_US/tutorial/benchmark.md
@@ -1,6 +1,12 @@
-# Benchmark
+# emqtt_bench Benchmark
 
 [emqtt_bench](https://github.com/emqx/emqtt_bench) is a concise and powerful MQTT protocol performance testing tool written with Erlang. If you need  testing services with large-scale scenarios and in-depth customization , the test service provided by EMQ partners [XMeter](https://www.xmeter.net/) is recommended.
+
+## Download
+
+Package downloads available on GitHub:
+
+- [emqtt-bench release](https://github.com/emqx/emqtt-bench/releases)
 
 ## Compile and install
 

--- a/zh_CN/getting-started/install-ee.md
+++ b/zh_CN/getting-started/install-ee.md
@@ -11,7 +11,7 @@ EMQ X 消息服务器可跨平台运行在 Linux、FreeBSD、macOS 或 openSUSE 
 
 ## EMQ X License 文件获取
 
-EMQ X 企业版内置了用于评估测试的 License（禁止用于生产环境），限制为 10 个客户端连接。可以联系商务或登陆 https://www.emqx.com/zh/apply-licenses/emqx 注册账号获取更大规格免费的试用 License。
+EMQ X 企业版内置了用于评估测试的 License（禁止用于生产环境），限制为 10 个客户端连接。可以联系商务或登陆 [https://www.emqx.com/zh/apply-licenses/emqx](https://www.emqx.com/zh/apply-licenses/emqx) 注册账号申请更大规格免费的试用 License。
 
 :::: tabs type:card
 
@@ -86,11 +86,9 @@ sudo yum-config-manager --add-repo https://repos.emqx.io/emqx-ee/redhat/centos/7
 sudo yum install emqx-ee
 ```
 
-::: tip
-如果提示接受 GPG 密钥，请确认密钥符合 fc84 1ba6 3775 5ca8 487b 1e3c c0b4 0946 3e640d53，如果符合，则接受该指纹。
-:::
+> 如果提示接受 GPG 密钥，请确认密钥符合 fc84 1ba6 3775 5ca8 487b 1e3c c0b4 0946 3e640d53，如果符合，则接受该指纹。
 
-5. 安装特定版本的 EMQ X
+1. 安装特定版本的 EMQ X
 
 - 查询可用版本
 

--- a/zh_CN/tutorial/benchmark.md
+++ b/zh_CN/tutorial/benchmark.md
@@ -13,9 +13,15 @@ category:
 ref:
 ---
 
-# 性能测试
+# emqtt_bench 性能测试
 
 [emqtt_bench](https://github.com/emqx/emqtt_bench) 是基于 Erlang 编写的，一个简洁强大的 MQTT 协议性能测试工具，如需大规模场景、深度定制化的测试服务推荐使用 EMQ 合作伙伴 [XMeter](https://www.xmeter.net/) 测试服务。
+
+## 下载安装
+
+GitHub 上提供了编译后的程序供下载：
+
+- [emqtt-bench release](https://github.com/emqx/emqtt-bench/releases)
 
 ## 编译安装
 


### PR DESCRIPTION
`::: tip` 在 card 的 `::: :::` 中间，导致 card 错乱