### PR TITLE
fix: delete bad linux tuning

### DIFF
--- a/en_US/tutorial/tune.md
+++ b/en_US/tutorial/tune.md
@@ -98,7 +98,6 @@ sysctl -w net.ipv4.tcp_wmem='1024 4096 16777216'
 TCP connection tracking:
 
 ```
-sysctl -w net.nf_conntrack_max=1000000
 sysctl -w net.netfilter.nf_conntrack_max=1000000
 sysctl -w net.netfilter.nf_conntrack_tcp_timeout_time_wait=30
 ```

--- a/zh_CN/tutorial/tune.md
+++ b/zh_CN/tutorial/tune.md
@@ -68,21 +68,20 @@ sysctl -w net.core.wmem_default=262144
 sysctl -w net.core.rmem_max=16777216
 sysctl -w net.core.wmem_max=16777216
 sysctl -w net.core.optmem_max=16777216
-    
+
 #sysctl -w net.ipv4.tcp_mem='16777216 16777216 16777216'
 sysctl -w net.ipv4.tcp_rmem='1024 4096 16777216'
 sysctl -w net.ipv4.tcp_wmem='1024 4096 16777216'
 ```
 TCP 连接追踪设置:
 ```bash
-sysctl -w net.nf_conntrack_max=1000000
 sysctl -w net.netfilter.nf_conntrack_max=1000000
 sysctl -w net.netfilter.nf_conntrack_tcp_timeout_time_wait=30
 ```
 TIME-WAIT Socket 最大数量、回收与重用设置:
 ```bash
 sysctl -w net.ipv4.tcp_max_tw_buckets=1048576
-    
+
 # 注意：不建议开启該设置，NAT 模式下可能引起连接 RST
 # sysctl -w net.ipv4.tcp_tw_recycle=1
 # sysctl -w net.ipv4.tcp_tw_reuse=1


### PR DESCRIPTION
nf_conntrack_max is in the net.netfilter namespace