### PR TITLE
fix: acl.conf uses `client` to identify the clientid "who"

### DIFF
--- a/en_US/advanced/acl-file.md
+++ b/en_US/advanced/acl-file.md
@@ -8,7 +8,7 @@ keywords:
 # 描述
 description:
 # 分类
-category: 
+category:
 # 引用
 ref: undefined
 ---
@@ -70,7 +70,7 @@ The syntax rules of `acl.conf` are included in the comments at the top. Those fa
     * `deny`
 - The second position of the tuple indicates the user to which the rule takes effect. The format that can be used is:
     * `{user, "dashboard"}`：The rule only takes effect for users whose Username  is dashboard
-    * `{clientid, "dashboard"}`：The rule only takes effect for users whose ClientId is dashboard
+    * `{client, "dashboard"}`：The rule only takes effect for users whose ClientId is dashboard
     * `{ipaddr, "127.0.0.1"}`：The rule only takes effect for users whose Source Address is "127.0.0.1"
     * `all`：The rule takes effect for all users
 - The third position of the tuple indicates the operation controlled by the rule with the possible value:

--- a/zh_CN/advanced/acl-file.md
+++ b/zh_CN/advanced/acl-file.md
@@ -8,7 +8,7 @@ keywords:
 # 描述
 description:
 # 分类
-category: 
+category:
 # 引用
 ref:
 ---
@@ -70,7 +70,7 @@ etc/acl.conf
 
 - 元组第二位：表示规则所生效的用户，可使用的格式为：
     * `{user, "dashboard"}`：表明规则仅对 *用户名 (Username)* 为 "dashboard" 的用户生效
-    * `{clientid, "dashboard"}`：表明规则仅对 *客户端标识 (ClientId)* 为 "dashboard" 的用户生效
+    * `{client, "dashboard"}`：表明规则仅对 *客户端标识 (ClientId)* 为 "dashboard" 的用户生效
     * `{ipaddr, "127.0.0.1"}`：表明规则仅对 *源地址* 为 "127.0.0.1" 的用户生效
     * `all`：表明规则对所有的用户都生效
 


### PR DESCRIPTION
The current code for 4.x expects `client` to denote the `clientid`
"who" in ACL rules.

As an aside, in 5.0, it seems to expect `clientid`.

Fixes emqx/emqx#7399 .