### PR TITLE
Update bridge-mqtt.md

### DIFF
--- a/en_US/bridge/bridge-mqtt.md
+++ b/en_US/bridge/bridge-mqtt.md
@@ -153,14 +153,14 @@ topic:   topic2/#
 ## Add Forwarded Topic for Specified Bridge
 
 ```bash
-$ ./bin/emqx_ctl bridges add-forwards emqx topic3/#
+$ ./bin/emqx_ctl bridges add-forward emqx topic3/#
 Add-forward topic successfully.
 ```
 
 ## Delete Forwarded Topic for Specified Bridge
 
 ```bash
-$ ./bin/emqx_ctl bridges del-forwards emqx topic3/#
+$ ./bin/emqx_ctl bridges del-forward emqx topic3/#
 Del-forward topic successfully.
 ```
 


### PR DESCRIPTION
The commands for Add and Delete forwarded topics had a typo. It should be add-forward and del-forward instead of add-forwards and del-forwards