### PR TITLE
refactor: hide x-www-form-urlencoded for http auhtn and authz from doc

### DIFF
--- a/en_US/security/authz/http.md
+++ b/en_US/security/authz/http.md
@@ -17,13 +17,14 @@ For untrusted environments, HTTPS should be used.
 
 ## Required HTTP Response Format
 
-- Response `Content-Type` can be `application/x-www-form-urlencoded` or `application/json`.
+- Response `Content-Type` must be `application/json`.
 - If the HTTP Status Code is `200`, the authorization result is granted by HTTP Body. It depends on the value of the `result` field:
     - `allow`: Allow Publish or Subscribe.
     - `deny`: Deny Publish or Subscribe.
     - `ignore`: Ignore this request, it will be handed over to the next authorizer.
 - If the HTTP Status Code is `204`, it means that this Publish or Subscribe request is allowed.
 
+<!--- NOTE: the code supports `application/x-www-form-urlencoded` too, but it is not very easy to extend in the future, hence hidden from doc -->
 
 ## Configuration
 
@@ -102,8 +103,8 @@ For `https://` urls `ssl` configuration must be enabled:
 
 ### `body`
 
-Optional arbitrary map for sending to the external API. For `post` requests it is sent as a JSON or www-form-urlencoded
-body. For `get` requests it is encoded as query parameters. The map keys and values can contain [placeholders](./authz.md#authorization-placeholders).
+Optional arbitrary map for sending to the external API. For `post` requests it is sent as a JSON body.
+For `get` requests it is encoded as query parameters. The map keys and values can contain [placeholders](./authz.md#authorization-placeholders).
 
 For different configurations `body` map will be encoded differently.
 
@@ -149,30 +150,6 @@ Assume an MQTT client is connected with clientid `id123`, username `iamuser` and
 
     {"username":"iamuser","topic":"foo/bar", "action": "publish"}
     ```
-* `POST` www-form-urlencoded request:
-    ```
-    {
-        method = post
-        url = "http://127.0.0.1:32333/auth/${clientid}"
-        body {
-            username = "${username}"
-            topic = "${topic}"
-            action = "${action}"
-        }
-        headers {
-            "content-type": "application/x-www-form-urlencoded"
-        }
-    }
-    ```
-    The resulting request will be:
-    ```
-    POST /auth/id123 HTTP/1.1
-    Content-Type: application/x-www-form-urlencoded
-    ... Other headers ...
-
-    username=iamuser&topic=foo%2Fbar&action=publish
-    ```
-
 ### `headers`
 
 Map with arbitrary HTTP headers for external requests, optional.
@@ -199,13 +176,12 @@ For `post` requests the default value is
 }
 ```
 
-`content-type` header value defines `body` encoding method for `post` requests. Possible values are:
-* `application/json` for JSON;
-* `application/x-www-form-urlencoded` for x-www-form-urlencoded format.
+`content-type` header value defines `body` encoding method for `post` requests, it must be `application/json`.
 
 ### `enable_pipelining`
 
-A positive integer value (default = 100) indicating the maximum number of send-ahead HTTP streams [HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining).
+A non-negative integer set maximum allowed async HTTP requests [HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining).
+Optional, default value is `100`, set `0` to disable.
 
 ### `pool_size`
 

--- a/zh_CN/security/authn/http.md
+++ b/zh_CN/security/authn/http.md
@@ -11,28 +11,27 @@ HTTP 认证使用外部自建 HTTP 应用认证数据源，根据 HTTP API 返�
     认证结果、是否为超级用户将分别由 Response Body 内的 `result` 和 `is_superuser` 字段值指示。</br>
   - 其他响应码将被认为 HTTP 认证请求执行失败。如 4xx、5xx 等。</br>
     此时认证结果使用缺省值 `"ignore"`，继续执行认证链。如果当前的 HTTP 认证器是链上的最后一个认证器，则认证失败，客户端将被拒绝连接。
-- HTTP 响应的编码格式可以是 `application/json` 和 `application/x-www-form-urlencoded`，HTTP 认证器会自动根据响应中的 `Content-Type` 选择解码方式。</br>
-  **示例**</br>
-  - ***HTTP Status Code 200***</br>
-    ```json
-    HTTP/1.1 200 OK
-    Headers: Content-Type: application/json
-    ...
-    Body:
-    {
-        "result": "allow" | "deny" | "ignore", // Default `"ignore"`
-        "is_superuser": true | false // Default `false`
-    }
-    ```
-    或
-    ```json
-    HTTP/1.1 200 OK
-    Headers:
-    Content-Type: application/x-www-form-urlencoded
-    ...
-    Body:
-    result=allow&is_superuser=true
-    ```
+- HTTP 响应的编码格式可以是 `application/json`。
+
+::: tip 从EMQX 4.x 迁移过来
+在 4.x 中，EMQX 仅用到了 HTTP API 返回的状态码，而内容则被丢弃。
+例如 `200` 表示 `allow`，`403` 表示 `deny`。
+
+因为缺乏丰富的表达能力，在 5.0 中对这块进行了不兼容的重构。
+:::
+
+### 示例
+
+```json
+HTTP/1.1 200 OK
+Headers: Content-Type: application/json
+...
+Body:
+{
+    "result": "allow" | "deny" | "ignore", // Default `"ignore"`
+    "is_superuser": true | false // Default `false`
+}
+```
 
 ::: danger
 推荐使用 `POST` 方法。 使用 `GET` 方法时，一些敏感信息（如纯文本密码）可以通过 HTTP 服务器日志记录暴露。
@@ -109,9 +108,8 @@ HTTP 认证由 `mechanism = password_based` 和 `backend = http` 标识。
 
 ### `body`
 
-请求模板。对于 `post` 请求，它以 JSON 或 www-form-urlencoded 形式在请求体中发送。对于 `get` 请求，它被编码为 URL 中的查询参数。映射键和值可以包含 [placeholders](./authn.md#认证占位符)。
-
-对于不同的配置，`body` 映射将被不同地编码。
+请求模板。对于 `post` 请求，它以 JSON 形式在请求体中发送。
+对于 `get` 请求，它被编码为 URL 中的查询参数。映射键和值可以包含 [placeholders](./authn.md#认证占位符)。
 
 假设一个 MQTT 客户端使用客户端标识符 `id123`、用户名 `iamuser` 和密码 `secret` 连接。
 
@@ -127,9 +125,9 @@ HTTP 认证由 `mechanism = password_based` 和 `backend = http` 标识。
        }
    }
    ```
-   
+
    最终的请求将是：
-   
+
    ```
    GET /auth/id123?username=iamuser&password=secret HTTP/1.1
    ... Headers ...
@@ -150,41 +148,15 @@ HTTP 认证由 `mechanism = password_based` 和 `backend = http` 标识。
        }
    }
    ```
-   
+
    最终的请求将是：
-   
+
    ```
    POST /auth/id123 HTTP/1.1
    Content-Type: application/json
    ... Other headers ...
-   
+
    {"username":"iamuser","password":"secret"}
-   ```
-
-3. `POST` `www-form-urlencoded` 格式的请求配置如下：
-
-   ```
-   {
-       method = post
-       url = "http://127.0.0.1:32333/auth/${clientid}"
-       body {
-           username = "${username}"
-           password = "${password}"
-       }
-       headers {
-           "content-type": "application/x-www-form-urlencoded"
-       }
-   }
-   ```
-   
-   最终的请求将是：
-   
-   ```
-   POST /auth/id123 HTTP/1.1
-   Content-Type: application/x-www-form-urlencoded
-   ... Other headers ...
-   
-   username=iamuser&password=secret
    ```
 
 ### `headers`
@@ -216,11 +188,11 @@ HTTP 认证由 `mechanism = password_based` 和 `backend = http` 标识。
 }
 ```
 
-`content-type` Header 的值定义了 `POST` 请求的 `body` 编码方法。可选值有 `application/json` 和 `application/x-www-form-urlencoded`。
+`content-type` Header 的值定义了 `POST` 请求的 `body` 编码方，必需为`application/json`。
 
 ### `enable_pipelining`
 
-布尔类型，表明是否启用 [HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining)。可选，默认值为 `true`。
+自然数，用于指定异步 HTTP 请求管线的最大数量[HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining)。可选，默认值为 `100`。设置为 `0` 时候关闭。
 
 ### `connect_timeout`, `request_timeout`, `retry_interval` and `max_retries`
 

--- a/zh_CN/security/authz/http.md
+++ b/zh_CN/security/authz/http.md
@@ -15,7 +15,7 @@ HTTP Authorizer 将授权的请求委托给外部 HTTP 服务器。
 
 ## 应答格式
 
-- `Content-Type` 支持 `application/x-www-form-urlencoded` 和 `application/json`
+- `Content-Type` 必需是 `application/json`
 - 当前 HTTP 返回状态码为 `200` 时，认证结果取决于 HTTP Body 中的 `result` 字段：
     - `allow`：允许此次发布/订阅。
     - `deny`：拒绝此次发布/订阅。
@@ -102,7 +102,7 @@ HTTP 的 `POST` 和 `GET` 方法都是支持的，但是各自有不一样的配
 ### `body`
 
 该配置项可选。用于构造一个 HTTP 请求的 body。
-如果是 `post` 请求，这个配置项会被编码成一个 JSON 或者 `www-form-urlencoded` 的字符串。
+如果是 `post` 请求，这个配置项会被编码成一个 JSON。
 如果是 `get` 请求，这个配置项会被翻译成 HTTP 的查询字符串。
 这些字段的名字和值中都可以使用[占位符](./authz.md#authorizer-配置中的占位符).
 
@@ -158,32 +158,6 @@ HTTP 的 `POST` 和 `GET` 方法都是支持的，但是各自有不一样的配
     {"username":"iamuser","topic":"foo/bar", "action": "publish"}
     ```
 
-* `POST` www-form-urlencoded request:
-    ```
-    {
-        method = post
-        url = "http://127.0.0.1:32333/auth/${clientid}"
-        body {
-            username = "${username}"
-            topic = "${topic}"
-            action = "${action}"
-        }
-        headers {
-            "content-type": "application/x-www-form-urlencoded"
-        }
-    }
-    ```
-
-    最终的 HTTP 请求会是下面这样：
-
-    ```
-    POST /auth/id123 HTTP/1.1
-    Content-Type: application/x-www-form-urlencoded
-    ... Other headers ...
-
-    username=iamuser&topic=foo%2Fbar&action=publish
-    ```
-
 ### `headers`
 
 根据配置来构造的 HTTP 头会是如下情况。
@@ -212,15 +186,11 @@ HTTP 的 `POST` 和 `GET` 方法都是支持的，但是各自有不一样的配
 }
 ```
 
-`content-type` 可以为 `post` 请求指定 `body` 的序列化格式，可能的值有：
-
-* `application/json` 序列化成 JSON;
-* `application/x-www-form-urlencoded` 序列化成 `x-www-form-urlencoded` 格式的字符串。
+`content-type` 可以为 `post` 请求指定 `body` 的序列化格式，必需为 `application/json`。
 
 ### `enable_pipelining`
 
-一个整形数字（默认100）用于指定流水线请求的最大数量 [HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining).
-
+自然数，用于指定异步 HTTP 请求管线的最大数量[HTTP pipelining](https://wikipedia.org/wiki/HTTP_pipelining)。可选，默认值为 `100`。设置为 `0` 时候关闭。
 
 ### `pool_size`
 


### PR DESCRIPTION
the features are in the code, but we hide them from the doc
reason: urlencoded args are not very easy to extend.
e.g. in the future, we will add ACL to http response body,
then JSON will be the only option