### PR TITLE
fix: outdated branch name in link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ book.pdf
 *.lock
 *.pdf
 .DS_Store
+.envrc
 /.idea/

--- a/en_US/advanced/hooks.md
+++ b/en_US/advanced/hooks.md
@@ -12,7 +12,7 @@ When the **Hooks** mechanism does not exist in the system, the entire event proc
 
 In the process, if a HookPoint where a function can be mounted is added, it will allow external plugins to mount multiple callback functions to form a call chain. Then, the internal event processing  can be extended and modified .
 
-The authentication plugin commonly used in the system is implemented according to this logic. Take the simplest  plugin of [emqx_auth_mnesia](https://github.com/emqx/emqx/tree/master/apps/emqx_auth_mnesia) as an example:
+The authentication plugin commonly used in the system is implemented according to this logic. Take the simplest  plugin of [emqx_auth_mnesia](https://github.com/emqx/emqx/tree/main-v4.3/apps/emqx_auth_mnesia) as an example:
 
 When only the `emqx_auth_mnesia` authentication plugin is enabled and anonymous authentication is disabled, according to the processing logic of the event according in the figure above, the logic of the authentication module at this time is:
 

--- a/zh_CN/advanced/hooks.md
+++ b/zh_CN/advanced/hooks.md
@@ -27,7 +27,7 @@ ref:
 
 而在这个过程中加入一个可挂载函数的点 (HookPoint)，允许外部插件挂载多个回调函数，形成一个调用链。达到对内部事件处理过程的扩展和修改。
 
-系统中常用到的认证插件则是按照该逻辑进行实现的。以最简单的 [emqx_auth_mnesia](https://github.com/emqx/emqx/tree/master/apps/emqx_auth_mnesia) 为例：
+系统中常用到的认证插件则是按照该逻辑进行实现的。以最简单的 [emqx_auth_mnesia](https://github.com/emqx/emqx/tree/main-v4.3/apps/emqx_auth_mnesia) 为例：
 
 在只开启 `emqx_auth_mnesia` 认证插件，且关闭匿名用户登录时。按照上图对事件的处理逻辑可知，此时认证模块的逻辑为：
 


### PR DESCRIPTION
outdated branch name `master`