### PR TITLE
fix: unsupported highlighting language `hocon`, use `hcl` as replace

### DIFF
--- a/en_US/access-control/authn/http.md
+++ b/en_US/access-control/authn/http.md
@@ -30,52 +30,52 @@ Body:
 }
 ```
 
-::: tip 
+::: tip
 
 EMQX 4.x Compatibility Notes
 
 In EMQX 4.x, only HTTP status code is used, but body is discarded, for example, `200` for `allow` and `403` for `deny`.
-Due to the lack of expressiveness, it has been redesigned to make use of HTTP body, and thus is not compatible with EMQX 5.0. 
+Due to the lack of expressiveness, it has been redesigned to make use of HTTP body, and thus is not compatible with EMQX 5.0.
 
 :::
 
 ## Configure with Dashboard
 
-You can use EMQX Dashboard to finish the relevant configuration. 
+You can use EMQX Dashboard to finish the relevant configuration.
 
-On [EMQX Dashboard](http://127.0.0.1:18083/#/authentication), click **Access Control** -> **Authentication** on the left navigation tree to enter the **Authentication** page. Click **Create** at the top right corner, then click to select **Password-Based** as **Mechanism**, and **HTTP Server** as **Backend**, this will lead us to the **Configuration** tab, as shown below. 
+On [EMQX Dashboard](http://127.0.0.1:18083/#/authentication), click **Access Control** -> **Authentication** on the left navigation tree to enter the **Authentication** page. Click **Create** at the top right corner, then click to select **Password-Based** as **Mechanism**, and **HTTP Server** as **Backend**, this will lead us to the **Configuration** tab, as shown below.
 
 ![HTTP](./assets/authn-http.png)
 
 
 
-**HTTP**: 
+**HTTP**:
 
 - **Method**: Select HTTP request method, optional values: `get`, `post`
 
-  :::tip 
+  :::tip
 
   The `POST` method is recommended. When using the `GET` method, some sensitive information (such as plain text passwords) may be exposed via HTTP server logs. Also, for untrusted environments, please use HTTPS.
    :::
 
 - **URL**: Enter the URL address of the HTTP service.
 
-- **Headers** (optional): HTTP request header. 
+- **Headers** (optional): HTTP request header.
 
 **Connection Configuration**:
 
 - **Pool size** (optional): Input an integer value to define the number of concurrent connections from an EMQX node to an HTTP server. Default: **8**. <!--有范围吗？-->
-- **Connect Timeout** (optional): Specify the waiting period before EMQX assumes the connection is timed out. Units supported include milliseconds, second, minute, and hour. 
+- **Connect Timeout** (optional): Specify the waiting period before EMQX assumes the connection is timed out. Units supported include milliseconds, second, minute, and hour.
 - **HTTP Pipelining** (optional): Input a positive integer to specify the maximum number of HTTP requests that can be sent without waiting for a response; default value: **100**.
-- **Request Timeout** (optional): Specify the waiting period before EMQX assumes the request is timed out. Units supported include milliseconds, second, minute, and hour. 
+- **Request Timeout** (optional): Specify the waiting period before EMQX assumes the request is timed out. Units supported include milliseconds, second, minute, and hour.
 
-**TLS Configuration**: Turn on the toggle switch if you want to enable TLS. 
+**TLS Configuration**: Turn on the toggle switch if you want to enable TLS.
 
 **Authentication configuration**:
 
 - **Body**: Request template; for `POST` requests, it is sent as a JSON in the request body; for `GET` requests, it is encoded as a Query String in the URL. Mapping keys and values support using [placeholder](./authn.md#authentication-placeholders).
 
-Now we can click **Create** to finish the settings. 
+Now we can click **Create** to finish the settings.
 
 ## Configure with Configuration Items
 
@@ -87,7 +87,7 @@ Below are the HTTP `POST` and `GET` request examples:
 
 ::: tab POST request
 
-```hocon
+```hcl
 {
     mechanism = password_based
     backend = http
@@ -110,7 +110,7 @@ Below are the HTTP `POST` and `GET` request examples:
 
 ::: tab GET request
 
-```hocon
+```hcl
 {
     mechanism = password_based
     backend = http

--- a/en_US/access-control/authn/mnesia.md
+++ b/en_US/access-control/authn/mnesia.md
@@ -1,6 +1,6 @@
 # Use Built-in Database
 
-You can use the built-in database of EMQX as a low-cost and out-of-the-box option for password authentication. After enabling, EMQX will save the client credentials in its built-in database (based on Mnesia) and manages data via REST API and Dashboard. This chapter will introduce how to use EMQX Dashboard and configuration items to configure. 
+You can use the built-in database of EMQX as a low-cost and out-of-the-box option for password authentication. After enabling, EMQX will save the client credentials in its built-in database (based on Mnesia) and manages data via REST API and Dashboard. This chapter will introduce how to use EMQX Dashboard and configuration items to configure.
 
 ::: tip
 
@@ -10,9 +10,9 @@ You can use the built-in database of EMQX as a low-cost and out-of-the-box optio
 
 ## Configure with Dashboard
 
-You can use EMQX Dashboard to set the built-in database for password authentication. 
+You can use EMQX Dashboard to set the built-in database for password authentication.
 
-On [EMQX Dashboard](http://127.0.0.1:18083/#/authentication), click **Access Control** -> **Authentication** on the left navigation tree to enter the **Authentication** page. Click **Create** at the top right corner, then click to select **Password-Based** as **Mechanism**, and **Built-in Database** as **Backend**, this will lead us to the **Configuration** tab, as shown below. 
+On [EMQX Dashboard](http://127.0.0.1:18083/#/authentication), click **Access Control** -> **Authentication** on the left navigation tree to enter the **Authentication** page. Click **Create** at the top right corner, then click to select **Password-Based** as **Mechanism**, and **Built-in Database** as **Backend**, this will lead us to the **Configuration** tab, as shown below.
 
 ![Built-in-database](./assets/authn-built-in-database.png)
 
@@ -20,20 +20,20 @@ On [EMQX Dashboard](http://127.0.0.1:18083/#/authentication), click **Access Con
 
 **UserID Type**: Specify the fields for client ID authentication; Options:  `username`, `clientid`（corresponding to the  `Username` or `Client Identifier` fields in the `CONNECT` message sent by the MQTT client).
 
-**Password Hash**: Select the Hash function for storing the password in the database, for example, plain, md5, sha, bcrypt, pbkdf2. There are some extra items to be configured based on the function you selected: 
+**Password Hash**: Select the Hash function for storing the password in the database, for example, plain, md5, sha, bcrypt, pbkdf2. There are some extra items to be configured based on the function you selected:
 
 1. If **plain**, **md5**, **sha**, **sha256** or **sha512** are selected, we also need to configure:
-   - **Salt Position**: Specify the way (**suffix**, **prefix**, or **disable**) to add salt (random data) to the password. You can keep the default value unless you are migrating user credentials from external storage into EMQX built-in database. Note: If you choose **plain**, the **Salt Position** should be set to **disable**.  
+   - **Salt Position**: Specify the way (**suffix**, **prefix**, or **disable**) to add salt (random data) to the password. You can keep the default value unless you are migrating user credentials from external storage into EMQX built-in database. Note: If you choose **plain**, the **Salt Position** should be set to **disable**.
 2. If **bcrypt** is selected, we also need to configure:
 
-   - **Salt Rounds**: Specify the calculation times of Hush function (2^Salt Rounds). Default value: **10**; Value range **4~31**. You are recommended to use a higher value for better protection. Note: Increasing the cost factor by 1 doubles the necessary time. 
-3. If **pkbdf2** is selected, we also need to configure: 
+   - **Salt Rounds**: Specify the calculation times of Hush function (2^Salt Rounds). Default value: **10**; Value range **4~31**. You are recommended to use a higher value for better protection. Note: Increasing the cost factor by 1 doubles the necessary time.
+3. If **pkbdf2** is selected, we also need to configure:
 
-   - **Pseudorandom Function**: Specify the Hush function for generating the key, for example,  sha256. 
+   - **Pseudorandom Function**: Specify the Hush function for generating the key, for example,  sha256.
    - **Iteration Count**: Specify the calculation times of Hush function. Default: **4096**.
-   - **Derived Key Length** (optional): Specify the generated key length. You can leave this field blank, then the key length will be determined by the pseudorandom function you selected. 
+   - **Derived Key Length** (optional): Specify the generated key length. You can leave this field blank, then the key length will be determined by the pseudorandom function you selected.
 
-Now we can click **Create** to finish the setting. 
+Now we can click **Create** to finish the setting.
 
 ## Configure with Configuration Items
 
@@ -41,7 +41,7 @@ You can also configuration items for the configuration. <!--For detailed steps, 
 
 Example:
 
-```hocon
+```hcl
 {
    backend = "built_in_database"
    mechanism = "password_based"

--- a/zh_CN/access-control/authn/authn.md
+++ b/zh_CN/access-control/authn/authn.md
@@ -128,7 +128,7 @@ EMQX 允许在认证阶段为客户端设置**超级用户**角色以及预设**
 
 以下为 EMQX 目前支持的散列算法：
 
-```hocon
+```hcl
 # simple algorithms
 password_hash_algorithm {
   name = sha256             # plain, md5, sha, sha512
@@ -193,10 +193,10 @@ Dashboard 底层调用了 HTTP API，提供了相对更加易用的可视化操�
 
 EMQX 支持为 MQTT 客户端配置多个认证器以组成认证链 <!--连接到对应概念-->，如以下代码示例中的 `authentication` 字段所示，认证器在数组中的顺序便是在认证链中执行的顺序：
 
-```hocon
+```hcl
 # emqx.conf
 
-# Specific global authentication chain for all MQTT listeners 
+# Specific global authentication chain for all MQTT listeners
 authentication = [
   ...
 ]

--- a/zh_CN/access-control/authn/http.md
+++ b/zh_CN/access-control/authn/http.md
@@ -78,7 +78,7 @@ Body:
 
 ::: tab POST 请求示例
 
-```hocon
+```hcl
 {
     mechanism = password_based
     backend = http
@@ -101,7 +101,7 @@ Body:
 
 ::: tab GET 请求示例
 
-```hocon
+```hcl
 {
     mechanism = password_based
     backend = http

--- a/zh_CN/access-control/authn/mnesia.md
+++ b/zh_CN/access-control/authn/mnesia.md
@@ -38,7 +38,7 @@ EMQX 通过内置数据库为用户提供了一种低成本、开箱即用的密
 
 示例配置：
 
-```hocon
+```hcl
 {
    backend = "built_in_database"
    mechanism = "password_based"

--- a/zh_CN/access-control/authn/mongodb.md
+++ b/zh_CN/access-control/authn/mongodb.md
@@ -100,7 +100,7 @@ MongoDB 认证器支持将认证数据存储为 MongoDB 文档。用户需要提
 您也可以通过配置文件完成相关配置，关于 单节点、ReplicaSet 和 Sharding 的详细配置方式，可参考：
 
 - [authn-mongodb:standalone](../../configuration/configuration-manual.md#authn-mongodb:standalone)
-- [authn-mongodb:sharded-cluster](../../configuration/configuration-manual.md#authn-mongodb:sharded-cluster) 
+- [authn-mongodb:sharded-cluster](../../configuration/configuration-manual.md#authn-mongodb:sharded-cluster)
 - [authn-mongodb:replica-set](../../configuration/configuration-manual.md#authn-mongodb:replica-set)
 
 以下为各部署模式下的配置文件示例：
@@ -109,7 +109,7 @@ MongoDB 认证器支持将认证数据存储为 MongoDB 文档。用户需要提
 
 ::: tab 单节点部署模式
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = mongodb
@@ -136,7 +136,7 @@ MongoDB 认证器支持将认证数据存储为 MongoDB 文档。用户需要提
 
 ::: tab Replica Set 部署模式
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = mongodb
@@ -164,7 +164,7 @@ MongoDB 认证器支持将认证数据存储为 MongoDB 文档。用户需要提
 
 ::: tab Sharding 部署模式
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = mongodb

--- a/zh_CN/access-control/authn/redis.md
+++ b/zh_CN/access-control/authn/redis.md
@@ -79,7 +79,7 @@ Redis 认证器支持使用 [Redis hashes](https://redis.io/docs/manual/data-typ
 
 ::: tab 单节点
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = redis
@@ -104,7 +104,7 @@ Redis 认证器支持使用 [Redis hashes](https://redis.io/docs/manual/data-typ
 
 ::: tab Redis Sentinel 部署模式
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = redis
@@ -130,7 +130,7 @@ Redis 认证器支持使用 [Redis hashes](https://redis.io/docs/manual/data-typ
 
 ::: tab Redis Cluster 部署模式
 
-```hocon
+```hcl
 {
   mechanism = password_based
   backend = redis

--- a/zh_CN/access-control/authn/scram.md
+++ b/zh_CN/access-control/authn/scram.md
@@ -20,7 +20,7 @@ SCRAM 认证仅支持使用 MQTT v5.0 的连接。
 
 配置示例如下：
 
-```hocon
+```hcl
 {
     mechanism = scram
     backend = built_in_database

--- a/zh_CN/access-control/authz/authz.md
+++ b/zh_CN/access-control/authz/authz.md
@@ -89,7 +89,7 @@ EMQX 授权支持的数据查询占位符如下：
 
 - `${cert_subject}`: 将在运行时被替换为客户端 TLS 证书的主题（Subject），仅适用于 TLS 连接。
 
-<!-- TODO 
+<!-- TODO
 确认 HTTP AuthZ 为什么会多出几个
 ?PH_PROTONAME,
 ?PH_MOUNTPOINT,
@@ -178,7 +178,7 @@ EMQX 授权支持与多种数据源集成，包括内置数据库、文件、MyS
 
 例如，MySQL 授权检查器的配置文件为：
 
-```hocon
+```hcl
 {
     enable = true
 
@@ -208,7 +208,7 @@ EMQX 提供了 3 种使用权限的配置方式，分别为：Dashboard、配置
 
 配置结构如下：
 
-```hocon
+```hcl
 authorization {
   sources = [
     { ...   },

--- a/zh_CN/access-control/authz/file.md
+++ b/zh_CN/access-control/authz/file.md
@@ -96,7 +96,7 @@ EMQX 已默认配置了基于文件的授权检查器。您可点击 **File** �
 
 配置示例：
 
-```hocon
+```hcl
 authorization {
   deny_action = ignore
   no_match = allow

--- a/zh_CN/access-control/authz/http.md
+++ b/zh_CN/access-control/authz/http.md
@@ -85,7 +85,7 @@ HTTP 授权必需使用 `type=http`的配置。
 
 使用 POST 请求配置的示例：
 
-```hocon
+```hcl
 {
     type = http
     enable = true
@@ -106,7 +106,7 @@ HTTP 授权必需使用 `type=http`的配置。
 
 使用 GET 请求配置的示例：
 
-```hocon
+```hcl
 {
     type = http
     enable = true
@@ -143,7 +143,7 @@ HTTP 授权必需使用 `type=http`的配置。
 
 如果 URL 为 `https`，必须同时启用 `ssl`：
 
-```hocon
+```hcl
 {
     ...
     url = "https://127.0.0.1:8080/authz?clientid=${clientid}"
@@ -165,7 +165,7 @@ HTTP 授权必需使用 `type=http`的配置。
 
 1. `GET` 请求配置如下：
 
-```hocon
+```hcl
 {
     method = get
     url = "http://127.0.0.1:8080/authz/${clientid}"
@@ -186,7 +186,7 @@ GET /authz/emqx_c?username=emqx_u&topic=t%2F1&action=publish HTTP/1.1
 
 2. `POST` JSON 格式的请求配置如下：
 
-```hocon
+```hcl
 {
     method = post
     url = "http://127.0.0.1:8080/authz/${clientid}"
@@ -217,7 +217,7 @@ Content-Type: application/json
 
 对于 `GET` 请求有以下默认 Headers：
 
-```hocon
+```hcl
 {
     "accept" = "application/json"
     "cache-control" = "no-cache"
@@ -230,7 +230,7 @@ Content-Type: application/json
 
 对于 `POST` 请求有以下默认 Headers：
 
-```hocon
+```hcl
 {
     "accept" = "application/json"
     "cache-control" = "no-cache"
@@ -250,7 +250,7 @@ Content-Type: application/json
 
 以下都是可选字段，
 
-```hocon
+```hcl
   connect_timeout = 15s # 连接超时
   max_retries = 5 # 最大重试次数
   request_timeout = 30s # 请求超时限制

--- a/zh_CN/access-control/authz/mnesia.md
+++ b/zh_CN/access-control/authz/mnesia.md
@@ -16,7 +16,7 @@ EMQX 通过内置数据库为用户提供了一种低成本、开箱即用的授
 
 代码示例：
 
-```hocon
+```hcl
 {
     type = built_in_database
     enable = true

--- a/zh_CN/access-control/authz/mongodb.md
+++ b/zh_CN/access-control/authz/mongodb.md
@@ -55,7 +55,7 @@ MongoDB Authorizer 必需有 `type = mongodb`。
 有三种不同的连接模式：
 
 Standalone：
-```hocon
+```hcl
 {
   type = mongodb
   enable = true
@@ -74,7 +74,7 @@ Standalone：
 
 [ReplicaSet](https://www.mongodb.com/docs/manual/reference/replica-configuration/)：
 
-```hocon
+```hcl
 {
   type = mongodb
   enable = true
@@ -94,7 +94,7 @@ Standalone：
 
 [Sharded Cluster](https://www.mongodb.com/docs/manual/sharding/)：
 
-```hocon
+```hcl
 {
   type = mongodb
   enable = true

--- a/zh_CN/access-control/authz/mysql.md
+++ b/zh_CN/access-control/authz/mysql.md
@@ -56,7 +56,7 @@ MySQL authorizer 由 `type=mysql` 标识。
 
 配置示例：
 
-```hocon
+```hcl
 {
   type = mysql
   enable = true

--- a/zh_CN/access-control/authz/postgresql.md
+++ b/zh_CN/access-control/authz/postgresql.md
@@ -54,7 +54,7 @@ PostgreSQL authorizer 由 `type=postgresql` 标识。
 
 配置示例：
 
-```hocon
+```hcl
 {
   type = postgresql
   enable = true

--- a/zh_CN/access-control/authz/redis.md
+++ b/zh_CN/access-control/authz/redis.md
@@ -42,7 +42,7 @@ Redis authorizer 由 `type=redis` 标识。
 
 Standalone Redis:
 
-```hocon
+```hcl
 {
     type = redis
     enable = true
@@ -60,7 +60,7 @@ Standalone Redis:
 
 [Redis Sentinel](https://redis.io/docs/manual/sentinel/):
 
-```hocon
+```hcl
 {
     type = redis
     enable = true
@@ -78,7 +78,7 @@ Standalone Redis:
 
 [Redis Cluster](https://redis.io/docs/manual/scaling/):
 
-```hocon
+```hcl
 {
     type = redis
     enable = true

--- a/zh_CN/configuration/configuration.md
+++ b/zh_CN/configuration/configuration.md
@@ -56,7 +56,7 @@ HOCON（Human-Optimized Config Object Notation）是一种可扩展的配置语�
 
 HOCON 值可以被记为类似 JSON 的对象，例如：
 
-```hocon
+```hcl
 node {
   name = "emqx@127.0.0.1"
   cookie = "mysecret"


### PR DESCRIPTION
See also about [prismjs supported languages](https://prismjs.com/#supported-languages)
And hocon is very similar with hcl.
Perhaps it don't have much effect on the highlighting of the hocon configuration file in the document.