### PR TITLE
chore: mongo time funcs only display in ee docs

### DIFF
--- a/en_US/data-integration/rule-sql-builtin-functions.md
+++ b/en_US/data-integration/rule-sql-builtin-functions.md
@@ -408,9 +408,10 @@ date_to_unix_ts('second', 'local', '%Y-%m-%d %H-%M-%S', '2022-05-26 18:40:12') =
 date_to_unix_ts('second', '%Y-%m-%d %H-%M-%S', '2022-05-26 10:40:12') = 1653561612
 ```
 
+{% emqxee %}
+
 **MongoDB Time Functions**
 
-{% emqxee %}
 | Function | Purpose | Parameters |
 | -------- | ------------------------------------|-------------------------- |
 | `mongo_date` | Create a mongodb ISODate type of now | - |

--- a/zh_CN/data-integration/rule-sql-builtin-functions.md
+++ b/zh_CN/data-integration/rule-sql-builtin-functions.md
@@ -394,6 +394,9 @@ date_to_unix_ts('second', '%Y-%m-%d %H-%M-%S', '2022-05-26 10:40:12') = 16535616
 ```
 
 {% emqxee %}
+
+**专用于 MongoDB 的时间函数**
+
 | Function | Purpose | Parameters | Returned value |
 | -------- | ------------------------------------|-------------------------- | --------------------------- |
 | `mongo_date` | 生成当前时间的 mongodb ISODate 类型 | - | ISODate 类型的时间 |


### PR DESCRIPTION
Before this fix, the `MongoDB Time Functions` shouldn't be displayed here:

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/13825269/234012983-4294a823-db6c-4cbe-bdd3-42e78e11a979.png">

https://www.emqx.io/docs/en/v5.0/data-integration/rule-sql-builtin-functions.html#time-and-date-functions
