### PR TITLE
Delete mcast cluster discovery from docs

### DIFF
--- a/cfg-manual-docgen/configuration-manual-ce-en.md
+++ b/cfg-manual-docgen/configuration-manual-ce-en.md
@@ -458,7 +458,7 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 
   *Default*: `manual`
 
-  *Optional*: `manual | static | mcast | dns | etcd | k8s`
+  *Optional*: `manual | static | dns | etcd | k8s`
 
   Service discovery method for the cluster nodes. Possible values are:
 - manual: Use <code>emqx ctl cluster</code> command to manage cluster.<br/>
@@ -518,11 +518,6 @@ there is no need to set this value.
   *Type*: `cluster_static`
 
 
-**cluster.mcast**
-
-  *Type*: `cluster_mcast`
-
-
 **cluster.dns**
 
   *Type*: `cluster_dns`
@@ -548,7 +543,6 @@ see [Create and manage clusters](../deploy/cluster/create-cluster.md)。
 | -------- | ------------------------------- |
 | manual   | Create cluster manually         |
 | static   | Autocluster by static node list |
-| mcast    | Autocluster by UDP Multicast    |
 | dns      | Autocluster by DNS A Record     |
 | etcd     | Autocluster using etcd          |
 | k8s      | Autocluster on Kubernetes       |
@@ -574,88 +568,6 @@ The new node joins the cluster by connecting to one of the bootstrap nodes.
   *Default*: `[]`
 
   List EMQX node names in the static cluster. See <code>node.name</code>.
-
-
-
-### Autocluster by IP Multicast
-
-
-Service discovery via UDP multicast.
-
-**cluster.mcast.addr**
-
-  *Type*: `string`
-
-  *Default*: `239.192.0.1`
-
-  Multicast IPv4 address.
-
-
-**cluster.mcast.ports**
-
-  *Type*: `array`
-
-  *Default*: `[4369, 4370]`
-
-  List of UDP ports used for service discovery.<br/>
-Note: probe messages are broadcast to all the specified ports.
-
-
-**cluster.mcast.iface**
-
-  *Type*: `string`
-
-  *Default*: `0.0.0.0`
-
-  Local IP address the node discovery service needs to bind to.
-
-
-**cluster.mcast.ttl**
-
-  *Type*: `integer`
-
-  *Default*: `255`
-
-  *Optional*: `0-255`
-
-  Time-to-live (TTL) for the outgoing UDP datagrams.
-
-
-**cluster.mcast.loop**
-
-  *Type*: `boolean`
-
-  *Default*: `true`
-
-  If <code>true</code>, loop UDP datagrams back to the local socket.
-
-
-**cluster.mcast.sndbuf**
-
-  *Type*: `bytesize`
-
-  *Default*: `16KB`
-
-  Size of the kernel-level buffer for outgoing datagrams.
-
-
-**cluster.mcast.recbuf**
-
-  *Type*: `bytesize`
-
-  *Default*: `16KB`
-
-  Size of the kernel-level buffer for incoming datagrams.
-
-
-**cluster.mcast.buffer**
-
-  *Type*: `bytesize`
-
-  *Default*: `32KB`
-
-  Size of the user-level buffer.
-
 
 
 ### Autocluster by DNS Record

--- a/cfg-manual-docgen/configuration-manual-ce-zh.md
+++ b/cfg-manual-docgen/configuration-manual-ce-zh.md
@@ -439,7 +439,7 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
 
   *默认值*: `manual`
 
-  *可选值*: `manual | static | mcast | dns | etcd | k8s`
+  *可选值*: `manual | static | dns | etcd | k8s`
 
   集群节点发现方式。可选值为:
 - manual: 使用 <code>emqx ctl cluster</code> 命令管理集群。<br/>
@@ -498,11 +498,6 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
   *类型*: `cluster_static`
 
 
-**cluster.mcast**
-
-  *类型*: `cluster_mcast`
-
-
 **cluster.dns**
 
   *类型*: `cluster_dns`
@@ -527,7 +522,6 @@ EMQX 支持多种策略的节点自动发现与集群，详见 [创建集群](..
 | ------ | ----------------------- |
 | manual | 手工命令创建集群        |
 | static | 静态节点列表自动集群    |
-| mcast  | UDP 组播方式自动集群    |
 | dns    | DNS A 记录自动集群      |
 | etcd   | 通过 etcd 自动集群      |
 | k8s    | Kubernetes 服务自动集群 |
@@ -555,95 +549,6 @@ cluster.discovery = manual
 指定固定的节点列表，多个节点间使用逗号 , 分隔。
 当 cluster.discovery_strategy 为 static 时，此配置项才有效。
 适合于节点数量较少且固定的集群。
-
-
-
-### 基于 mcast 组播自动集群
-
-
-UDP 组播服务发现。
-
-**cluster.mcast.addr**
-
-  *类型*: `string`
-
-  *默认值*: `239.192.0.1`
-
-  指定多播 IPv4 地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.ports**
-
-  *类型*: `array`
-
-  *默认值*: `[4369, 4370]`
-
-  指定多播端口。如有多个端口使用逗号 , 分隔。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.iface**
-
-  *类型*: `string`
-
-  *默认值*: `0.0.0.0`
-
-  指定节点发现服务需要绑定到本地 IP 地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.ttl**
-
-  *类型*: `integer`
-
-  *默认值*: `255`
-
-  *可选值*: `0-255`
-
-  指定多播的 Time-To-Live 值。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.loop**
-
-  *类型*: `boolean`
-
-  *默认值*: `true`
-
-  设置多播的报文是否投递到本地回环地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.sndbuf**
-
-  *类型*: `bytesize`
-
-  *默认值*: `16KB`
-
-  外发数据报的内核级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.recbuf**
-
-  *类型*: `bytesize`
-
-  *默认值*: `16KB`
-
-  接收数据报的内核级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.buffer**
-
-  *类型*: `bytesize`
-
-  *默认值*: `32KB`
-
-  用户级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
 
 
 ### 基于 DNS 记录自动集群

--- a/cfg-manual-docgen/configuration-manual-ee-en.md
+++ b/cfg-manual-docgen/configuration-manual-ee-en.md
@@ -458,7 +458,7 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 
   *Default*: `manual`
 
-  *Optional*: `manual | static | mcast | dns | etcd | k8s`
+  *Optional*: `manual | static | dns | etcd | k8s`
 
   Service discovery method for the cluster nodes. Possible values are:
 - manual: Use <code>emqx ctl cluster</code> command to manage cluster.<br/>
@@ -518,11 +518,6 @@ there is no need to set this value.
   *Type*: `cluster_static`
 
 
-**cluster.mcast**
-
-  *Type*: `cluster_mcast`
-
-
 **cluster.dns**
 
   *Type*: `cluster_dns`
@@ -548,7 +543,6 @@ see [Create and manage clusters](../deploy/cluster/create-cluster.md)。
 | -------- | ------------------------------- |
 | manual   | Create cluster manually         |
 | static   | Autocluster by static node list |
-| mcast    | Autocluster by UDP Multicast    |
 | dns      | Autocluster by DNS A Record     |
 | etcd     | Autocluster using etcd          |
 | k8s      | Autocluster on Kubernetes       |
@@ -574,88 +568,6 @@ The new node joins the cluster by connecting to one of the bootstrap nodes.
   *Default*: `[]`
 
   List EMQX node names in the static cluster. See <code>node.name</code>.
-
-
-
-### Autocluster by IP Multicast
-
-
-Service discovery via UDP multicast.
-
-**cluster.mcast.addr**
-
-  *Type*: `string`
-
-  *Default*: `239.192.0.1`
-
-  Multicast IPv4 address.
-
-
-**cluster.mcast.ports**
-
-  *Type*: `array`
-
-  *Default*: `[4369, 4370]`
-
-  List of UDP ports used for service discovery.<br/>
-Note: probe messages are broadcast to all the specified ports.
-
-
-**cluster.mcast.iface**
-
-  *Type*: `string`
-
-  *Default*: `0.0.0.0`
-
-  Local IP address the node discovery service needs to bind to.
-
-
-**cluster.mcast.ttl**
-
-  *Type*: `integer`
-
-  *Default*: `255`
-
-  *Optional*: `0-255`
-
-  Time-to-live (TTL) for the outgoing UDP datagrams.
-
-
-**cluster.mcast.loop**
-
-  *Type*: `boolean`
-
-  *Default*: `true`
-
-  If <code>true</code>, loop UDP datagrams back to the local socket.
-
-
-**cluster.mcast.sndbuf**
-
-  *Type*: `bytesize`
-
-  *Default*: `16KB`
-
-  Size of the kernel-level buffer for outgoing datagrams.
-
-
-**cluster.mcast.recbuf**
-
-  *Type*: `bytesize`
-
-  *Default*: `16KB`
-
-  Size of the kernel-level buffer for incoming datagrams.
-
-
-**cluster.mcast.buffer**
-
-  *Type*: `bytesize`
-
-  *Default*: `32KB`
-
-  Size of the user-level buffer.
-
 
 
 ### Autocluster by DNS Record

--- a/cfg-manual-docgen/configuration-manual-ee-zh.md
+++ b/cfg-manual-docgen/configuration-manual-ee-zh.md
@@ -439,7 +439,7 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
 
   *默认值*: `manual`
 
-  *可选值*: `manual | static | mcast | dns | etcd | k8s`
+  *可选值*: `manual | static | dns | etcd | k8s`
 
   集群节点发现方式。可选值为:
 - manual: 使用 <code>emqx ctl cluster</code> 命令管理集群。<br/>
@@ -498,11 +498,6 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
   *类型*: `cluster_static`
 
 
-**cluster.mcast**
-
-  *类型*: `cluster_mcast`
-
-
 **cluster.dns**
 
   *类型*: `cluster_dns`
@@ -527,7 +522,6 @@ EMQX 支持多种策略的节点自动发现与集群，详见 [创建集群](..
 | ------ | ----------------------- |
 | manual | 手工命令创建集群        |
 | static | 静态节点列表自动集群    |
-| mcast  | UDP 组播方式自动集群    |
 | dns    | DNS A 记录自动集群      |
 | etcd   | 通过 etcd 自动集群      |
 | k8s    | Kubernetes 服务自动集群 |
@@ -555,95 +549,6 @@ cluster.discovery = manual
 指定固定的节点列表，多个节点间使用逗号 , 分隔。
 当 cluster.discovery_strategy 为 static 时，此配置项才有效。
 适合于节点数量较少且固定的集群。
-
-
-
-### 基于 mcast 组播自动集群
-
-
-UDP 组播服务发现。
-
-**cluster.mcast.addr**
-
-  *类型*: `string`
-
-  *默认值*: `239.192.0.1`
-
-  指定多播 IPv4 地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.ports**
-
-  *类型*: `array`
-
-  *默认值*: `[4369, 4370]`
-
-  指定多播端口。如有多个端口使用逗号 , 分隔。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.iface**
-
-  *类型*: `string`
-
-  *默认值*: `0.0.0.0`
-
-  指定节点发现服务需要绑定到本地 IP 地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.ttl**
-
-  *类型*: `integer`
-
-  *默认值*: `255`
-
-  *可选值*: `0-255`
-
-  指定多播的 Time-To-Live 值。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.loop**
-
-  *类型*: `boolean`
-
-  *默认值*: `true`
-
-  设置多播的报文是否投递到本地回环地址。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.sndbuf**
-
-  *类型*: `bytesize`
-
-  *默认值*: `16KB`
-
-  外发数据报的内核级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.recbuf**
-
-  *类型*: `bytesize`
-
-  *默认值*: `16KB`
-
-  接收数据报的内核级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
-
-**cluster.mcast.buffer**
-
-  *类型*: `bytesize`
-
-  *默认值*: `32KB`
-
-  用户级缓冲区的大小。
-当 cluster.discovery_strategy 为 mcast 时，此配置项才有效。
-
 
 
 ### 基于 DNS 记录自动集群

--- a/en_US/configuration/cluster.md
+++ b/en_US/configuration/cluster.md
@@ -54,7 +54,7 @@ Where,
 | Configuration Item       | Description                                                  | Default Value | Optional Values                                   |
 | ------------------------ | ------------------------------------------------------------ | ------------- | ------------------------------------------------- |
 | `name`                   | This sets the name of the cluster                            | `emqxcl`      |                                                   |
-| `discovery_strategy`     | This sets the node discovery strategy for the cluster.       | `manual`      | `manual`, `static`, `mcast`, `DNS`, `etcd`, `k8s` |
+| `discovery_strategy`     | This sets the node discovery strategy for the cluster.       | `manual`      | `manual`, `static`, `DNS`, `etcd`, `k8s`          |
 | `core_nodes`             | This sets the core nodes that this replicant code will connect to.<br>Multiple nodes can be added here, separated with a `,` | --            | --                                                |
 | `driver`                 | This sets the transport protocol for inter-EMQX node communication. | `tcp`         | `tcp`, `SSL`                                      |
 | `ssl_options`            | This sets the SSL/TLS configuration options for the listener, it has three properties | --            | --                                                |

--- a/en_US/deploy/cluster/create-cluster.md
+++ b/en_US/deploy/cluster/create-cluster.md
@@ -25,12 +25,9 @@ One of the crucial steps for EMQX clustering is node discovery, which enables in
 | -------- | ----------------------------------------- |
 | `manual` | Create a cluster through manual command   |
 | `static` | Create a cluster using a static node list |
-| `mcast`* | Create a cluster through UDP multicast    |
 | `dns`    | Create a cluster using DNS A and SRV records      |
 | `etcd`   | Create a cluster via etcd                 |
 | `k8s`    | Create a cluster via Kubernetes service   |
-
-[^*]: The multicast discovery strategy has been deprecated and will be removed in future releases.
 
 ## Before You Begin
 

--- a/en_US/deploy/cluster/introduction.md
+++ b/en_US/deploy/cluster/introduction.md
@@ -48,12 +48,9 @@ EMQX supports several node discovery strategies:
 | -------- | --------------------------------------- |
 | `manual` | Manually create a cluster with commands |
 | `static` | Autocluster through static node list    |
-| `mcast`* | Create a cluster through UDP multicast  |
 | `DNS`    | Autocluster through DNS A and SRV records        |
 | `etcd`   | Autocluster through etcd                |
 | `k8s`    | Autocluster provided by Kubernetes      |
-
-[^*]: The multicast discovery strategy has been deprecated and will be removed in future releases.
 
 ### Network Partition Autoheal
 

--- a/zh_CN/configuration/cluster.md
+++ b/zh_CN/configuration/cluster.md
@@ -54,7 +54,7 @@ Where,
 | Configuration Item       | Description                                                  | Default Value | Optional Values                                   |
 | ------------------------ | ------------------------------------------------------------ | ------------- | ------------------------------------------------- |
 | `name`                   | This sets the name of the cluster                            | `emqxcl`      |                                                   |
-| `discovery_strategy`     | This sets the node discovery strategy for the cluster.       | `manual`      | `manual`, `static`, `mcast`, `DNS`, `etcd`, `k8s` |
+| `discovery_strategy`     | This sets the node discovery strategy for the cluster.       | `manual`      | `manual`, `static`, `DNS`, `etcd`, `k8s` |
 | `core_nodes`             | This sets the core nodes that this replicant code will connect to.<br>Multiple nodes can be added here, separated with a `,` | --            | --                                                |
 | `driver`                 | This sets the transport protocol for inter-EMQX node communication. | `tcp`         | `tcp`, `SSL`                                      |
 | `ssl_options`            | This sets the SSL/TLS configuration options for the listener, it has three properties | --            | --                                                |

--- a/zh_CN/deploy/cluster/create-cluster.md
+++ b/zh_CN/deploy/cluster/create-cluster.md
@@ -34,7 +34,7 @@ EMQX 支持手动创建集群，也支持通过多种方式自动集群，本章
 
     ```bash
     cluster {
-        ## 可选 manual | static | mcast | dns | etcd | K8s
+        ## 可选 manual | static | dns | etcd | K8s
         discovery_strategy  =  manual
     }
     ```
@@ -119,7 +119,7 @@ EMQX 默认配置为手动创建集群，您可以通过 `emqx.conf` 配置文�
 
 ```bash
 cluster {
-    ## 可选 manual | static | mcast | dns | etcd | K8s
+    ## 可选 manual | static | dns | etcd | K8s
     discovery_strategy  =  manual
 }
 ```


### PR DESCRIPTION
mcast is deprecated since 5.0,
in 5.1, the code is still there, but we remove the docs.

the remaining parts are schema json and generated md which will be updated in a separate process