### PR TITLE
nginx负载均衡，添加 proxy_protocol on;

### DIFF
--- a/en_US/deploy/cluster/lb.md
+++ b/en_US/deploy/cluster/lb.md
@@ -138,6 +138,7 @@ stream {
       status_zone tcp_server;
       proxy_pass stream_backend;
       proxy_buffer_size 4k;
+      proxy_protocol on;
       ssl_handshake_timeout 15s;
       ssl_certificate     /etc/emqx/certs/cert.pem;
       ssl_certificate_key /etc/emqx/certs/key.pem;

--- a/zh_CN/deploy/cluster/lb.md
+++ b/zh_CN/deploy/cluster/lb.md
@@ -129,6 +129,7 @@ stream {
       listen 8883 ssl;
       proxy_pass stream_backend;
       proxy_buffer_size 4k;
+      proxy_protocol on;
       ssl_handshake_timeout 15s;
       ssl_certificate     /etc/emqx/certs/cert.pem;
       ssl_certificate_key /etc/emqx/certs/key.pem;


### PR DESCRIPTION
集群部署时，nginx 负载均衡，需要添加 proxy_protocol on;  否则无法连接 emqx