### PR TITLE
docs: delete UDP mcast clustering

### DIFF
--- a/cfg-manual-docgen/configuration-manual-ce-en.md
+++ b/cfg-manual-docgen/configuration-manual-ce-en.md
@@ -393,7 +393,7 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 
   *Default*: `manual`
 
-  *Optional*: `manual | static | dns | etcd | k8s | mcast`
+  *Optional*: `manual | static | dns | etcd | k8s`
 
   Service discovery method for the cluster nodes. Possible values are:
 - manual: Use <code>emqx ctl cluster</code> command to manage cluster.<br/>
@@ -401,7 +401,6 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 - dns: Use DNS A record to discover peer nodes.<br/>
 - etcd: Use etcd to discover peer nodes.<br/>
 - k8s: Use Kubernetes API to discover peer pods.
-- mcast: Deprecated since 5.1, will be removed in 5.2.
   This supports discovery via UDP multicast.
 
 
@@ -468,7 +467,6 @@ see [Create and manage clusters](../deploy/cluster/create-cluster.md)。
 | -------- | ------------------------------- |
 | manual   | Create cluster manually         |
 | static   | Autocluster by static node list |
-| mcast    | Autocluster by UDP Multicast    |
 | dns      | Autocluster by DNS A Record     |
 | etcd     | Autocluster using etcd          |
 | k8s      | Autocluster on Kubernetes       |

--- a/cfg-manual-docgen/configuration-manual-ce-zh.md
+++ b/cfg-manual-docgen/configuration-manual-ce-zh.md
@@ -374,7 +374,7 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
 
   *默认值*: `manual`
 
-  *可选值*: `manual | static | dns | etcd | k8s | mcast`
+  *可选值*: `manual | static | dns | etcd | k8s`
 
   集群节点发现方式。可选值为:
 - manual: 使用 <code>emqx ctl cluster</code> 命令管理集群。<br/>
@@ -444,7 +444,6 @@ EMQX 支持多种策略的节点自动发现与集群，详见 [创建集群](..
 | ------ | ----------------------- |
 | manual | 手工命令创建集群        |
 | static | 静态节点列表自动集群    |
-| mcast  | UDP 组播方式自动集群    |
 | dns    | DNS A 记录自动集群      |
 | etcd   | 通过 etcd 自动集群      |
 | k8s    | Kubernetes 服务自动集群 |

--- a/cfg-manual-docgen/configuration-manual-ee-en.md
+++ b/cfg-manual-docgen/configuration-manual-ee-en.md
@@ -393,7 +393,7 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 
   *Default*: `manual`
 
-  *Optional*: `manual | static | dns | etcd | k8s | mcast`
+  *Optional*: `manual | static | dns | etcd | k8s`
 
   Service discovery method for the cluster nodes. Possible values are:
 - manual: Use <code>emqx ctl cluster</code> command to manage cluster.<br/>
@@ -401,7 +401,6 @@ EMQX nodes can form a cluster to scale up the total capacity.<br/>
 - dns: Use DNS A record to discover peer nodes.<br/>
 - etcd: Use etcd to discover peer nodes.<br/>
 - k8s: Use Kubernetes API to discover peer pods.
-- mcast: Deprecated since 5.1, will be removed in 5.2.
   This supports discovery via UDP multicast.
 
 
@@ -468,7 +467,6 @@ see [Create and manage clusters](../deploy/cluster/create-cluster.md)。
 | -------- | ------------------------------- |
 | manual   | Create cluster manually         |
 | static   | Autocluster by static node list |
-| mcast    | Autocluster by UDP Multicast    |
 | dns      | Autocluster by DNS A Record     |
 | etcd     | Autocluster using etcd          |
 | k8s      | Autocluster on Kubernetes       |

--- a/cfg-manual-docgen/configuration-manual-ee-zh.md
+++ b/cfg-manual-docgen/configuration-manual-ee-zh.md
@@ -374,7 +374,7 @@ EMQX 节点可以组成一个集群，以提高总容量。<br/> 这里指定了
 
   *默认值*: `manual`
 
-  *可选值*: `manual | static | dns | etcd | k8s | mcast`
+  *可选值*: `manual | static | dns | etcd | k8s`
 
   集群节点发现方式。可选值为:
 - manual: 使用 <code>emqx ctl cluster</code> 命令管理集群。<br/>
@@ -444,7 +444,6 @@ EMQX 支持多种策略的节点自动发现与集群，详见 [创建集群](..
 | ------ | ----------------------- |
 | manual | 手工命令创建集群        |
 | static | 静态节点列表自动集群    |
-| mcast  | UDP 组播方式自动集群    |
 | dns    | DNS A 记录自动集群      |
 | etcd   | 通过 etcd 自动集群      |
 | k8s    | Kubernetes 服务自动集群 |


### PR DESCRIPTION
The docs were updated in release-5.1 long ago.
However there were a few leftovers.