### PR TITLE
fix(haproxy): fix can not enable stick session bug

### DIFF
--- a/en_US/deploy/cluster/lb-haproxy.md
+++ b/en_US/deploy/cluster/lb-haproxy.md
@@ -169,6 +169,8 @@ backend mqtt_backend
 frontend mqtt_servers
   bind *:1883
   mode tcp
+  # Wait for the buffer to fill up to parse the MQTT message
+  tcp-request inspect-delay 10s
   # Reject non-MQTT connections
   tcp-request content reject unless { req.payload(0，0)，mqtt_is_valid }
   default_backend mqtt_backend

--- a/zh_CN/deploy/cluster/lb-haproxy.md
+++ b/zh_CN/deploy/cluster/lb-haproxy.md
@@ -169,6 +169,8 @@ backend mqtt_backend
 frontend mqtt_servers
   bind *:1883
   mode tcp
+  # 等待缓冲区填满，以便解析 MQTT 报文
+  tcp-request inspect-delay 10s
   # 拒绝非 MQTT 连接
   tcp-request content reject unless { req.payload(0，0)，mqtt_is_valid }
   default_backend mqtt_backend


### PR DESCRIPTION
https://discourse.haproxy.org/t/stick-table-fails-when-balancing-mqtt-traffic-any-suggestions-or-debugging-hints/7359/6

https://askemq.com/t/topic/7358

@CrazyWisdom 
We should update this blog:
https://www.emqx.com/zh/blog/mqtt-broker-clustering-part-2-sticky-session-load-balancing