### PR TITLE
Fix default for cluster.autoclean

### DIFF
--- a/en_US/deploy/cluster/introduction.md
+++ b/en_US/deploy/cluster/introduction.md
@@ -68,10 +68,10 @@ If a network partition is detected, EMQX will isolate the affected nodes and con
 
 Cluster node autoclean feature will automatically remove the disconnected nodes from the cluster after the configured time interval. This feature helps to ensure that the cluster is running efficiently and prevent performance degradation over time.
 
-This feature is enabled by default, you can customize the waiting period before removing the disconnected nodes. Default: `5m`
+This feature is enabled by default, you can customize the waiting period before removing the disconnected nodes. Default: `24h`
 
 ```bash
-cluster.autoclean = 5m
+cluster.autoclean = 24h
 ```
 
 ### Session Across Nodes


### PR DESCRIPTION
https://github.com/emqx/emqx/blob/master/apps/emqx_conf/src/emqx_conf_schema.erl#L176

```
{"autoclean",
            sc(
                emqx_schema:duration(),
                #{
                    mapping => "mria.cluster_autoclean",
                    default => <<"24h">>,
                    desc => ?DESC(cluster_autoclean),
                    'readOnly' => true
                }
            )},
```