### PR TITLE
docs(http-api): remove qos from unsubscribe_batch api example

### DIFF
--- a/en_US/advanced/http-api.md
+++ b/en_US/advanced/http-api.md
@@ -883,7 +883,7 @@ Unsubscribe in batch.
 Unsubscribe from `a`,` b` topics at one time
 
 ```bash
-$ curl -i --basic -u admin:public -X POST "http://localhost:8081/api/v4/mqtt/unsubscribe_batch" -d '[{"topic":"a","qos":1,"clientid":"example"},{"topic":"b","qos":1,"clientid":"example"}]'
+$ curl -i --basic -u admin:public -X POST "http://localhost:8081/api/v4/mqtt/unsubscribe_batch" -d '[{"topic":"a","clientid":"example"},{"topic":"b","clientid":"example"}]'
 
 {"code":0}
 ```


### PR DESCRIPTION
QoS is not handled when unsubscribing a topic.
Although the spec allows subscribing to a topic more than once and can use different QoS, but our code does not handle QoS.