### PR TITLE
docs: refine doc for TLS certfile related fields

### DIFF
--- a/en_US/configuration/cluster.md
+++ b/en_US/configuration/cluster.md
@@ -61,6 +61,7 @@ Where,
 | `ssl_options.cacertfile` | PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates. | --            | --                                                |
 | `ssl_options.certfile`   | PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain. | --            | --                                                |
 | `ssl_options.keyfile`    | PEM file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
+| `ssl_options.fail_if_no_peer_cert` | If set to true, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the client sends an invalid certificate (an empty certificate is considered valid). | --            | --                                                |
 
 {% emqxce %}
 

--- a/en_US/configuration/cluster.md
+++ b/en_US/configuration/cluster.md
@@ -58,9 +58,9 @@ Where,
 | `core_nodes`             | This sets the core nodes that this replicant code will connect to.<br />Multiple nodes can be added here, separated with a `,` | --            | --                                                |
 | `driver`                 | This sets the transport protocol for inter-EMQX node communication. | `tcp`         | `tcp`, `SSL`                                      |
 | `ssl_options`            | This sets the SSL/TLS configuration options for the listener, it has three properties | --            | --                                                |
-| `ssl_options.cacertfile` | This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates. | --            | --                                                |
-| `ssl_options.certfile`   | This sets the path to the file containing the SSL/TLS certificate for the listener. | --            | --                                                |
-| `ssl_options.keyfile`    | This sets the path to the file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
+| `ssl_options.cacertfile` | PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates. | --            | --                                                |
+| `ssl_options.certfile`   | PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain. | --            | --                                                |
+| `ssl_options.keyfile`    | PEM file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
 
 {% emqxce %}
 

--- a/en_US/configuration/dashboard.md
+++ b/en_US/configuration/dashboard.md
@@ -23,9 +23,9 @@ Where,
 - `bind  =  "0.0.0.0:18083"`  is to set the network address and port number that the listener will bind to. In this case, the listener will bind to all available network interfaces (`0.0.0.0`) on port `18083`.
 - `max_connections  =  512` is to set the maximum number of concurrent connections that the listener will accept. In this case, the maximum number of connections is set to `512`.
 - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-  - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-  - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-  - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+  - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+  - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the server certificate to form a chain.
+  - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
 {% emqxce %}
 

--- a/en_US/configuration/listener.md
+++ b/en_US/configuration/listener.md
@@ -44,6 +44,8 @@ listeners.ssl.default {
     cacertfile = "etc/certs/cacert.pem"
     certfile = "etc/certs/cert.pem"
     keyfile = "etc/certs/key.pem"
+    verify = verify_none
+    fail_if_no_peer_cert = false
   }
 }
 ```
@@ -57,8 +59,8 @@ where:
     - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
     - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
-
- 
+    - `verify`:  Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'.
+    - `fail_if_no_peer_cert`: If set to true, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the client sends an invalid certificate (an empty certificate is considered valid).
 
 ## Configure WebSocket Listener
 
@@ -101,7 +103,7 @@ listeners.wss.default {
     certfile = "etc/certs/cert.pem"
     keyfile = "etc/certs/key.pem"
   }
-  }
+}
 ```
 
 where:
@@ -110,12 +112,10 @@ where:
   - `bind` is the IP address and port of the listener, here it will listen to all incoming traffic from any IP address on port `8084`. 
   - `max_connection` is the maximum number of concurrent connections allowed by the listener, default value: `infinity`.
   - `websocket.mqtt_path` is to set the path to the WebSocket’s MQTT protocol, which is `/mqtt` by default. 
-    - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-      - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-      - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
-      - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
-
-
+  - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
+    - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+    - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
 <!--To add QUIC-->
 

--- a/en_US/configuration/listener.md
+++ b/en_US/configuration/listener.md
@@ -54,9 +54,9 @@ where:
   - `bind` is the IP address and port of the listener, here it will listen to all incoming traffic from any IP address on port `8883`. 
   - `max_connection` is the maximum number of concurrent connections allowed by the listener, default value: `infinity`.
   - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-    - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-    - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-    - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+    - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+    - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
  
 
@@ -111,9 +111,9 @@ where:
   - `max_connection` is the maximum number of concurrent connections allowed by the listener, default value: `infinity`.
   - `websocket.mqtt_path` is to set the path to the WebSocket’s MQTT protocol, which is `/mqtt` by default. 
     - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-      - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-      - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-      - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+      - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+      - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+      - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
 
 

--- a/en_US/deploy/cluster/security.md
+++ b/en_US/deploy/cluster/security.md
@@ -41,6 +41,10 @@ rpc {
   certfile = "/path/to/cert/domain.pem"
   # PEM format file containing the private key corresponding to the SSL/TLS certificate
   keyfile = "/path/to/cert/domain.key"
+  # Set to 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'.
+  verify = verify_peer
+  # If set to true, the handshake fails if the peer does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the peer sends an invalid certificate (an empty certificate is considered valid).
+  fail_if_no_peer_cert = true
 }
 ```
 

--- a/en_US/deploy/cluster/security.md
+++ b/en_US/deploy/cluster/security.md
@@ -35,9 +35,12 @@ To configure TLS/SSL for cluster RPC below configuration items should be set in 
 ```
 rpc {
   driver = ssl
-  certfile = /path/to/cert/domain.pem
-  cacertfile = /path/to/cert/ca.pem
-  keyfile = /path/to/cert/domain.key
+  # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the cluster peers.
+  cacertfile = "/path/to/cert/ca.pem"
+  # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+  certfile = "/path/to/cert/domain.pem"
+  # PEM format file containing the private key corresponding to the SSL/TLS certificate
+  keyfile = "/path/to/cert/domain.key"
 }
 ```
 

--- a/en_US/network/crl.md
+++ b/en_US/network/crl.md
@@ -27,10 +27,12 @@ listeners.ssl.default {
     cacertfile = "/etc/emqx/certs/ca.pem"
     # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     certfile = "/etc/emqx/certs/server.pem"
-    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+    # PEM format file containing the private key corresponding to the SSL/TLS certificate.
     keyfile = "/etc/emqx/certs/server.key"
     # Must verify peer certificats
     verify = verify_peer
+    # Force the client to send a non-empty certificate, otherwise fail the TLS handshake.
+    fail_if_no_peer_cert = true
     # Also verify client certificate's revocation status
     enable_crl_check = true
   }

--- a/en_US/network/crl.md
+++ b/en_US/network/crl.md
@@ -23,10 +23,15 @@ Example configuration to enable CRL Check:
 listeners.ssl.default {
   bind = "0.0.0.0:8883"
   ssl_options {
-    keyfile = "/etc/emqx/certs/server.key"
-    certfile = "/etc/emqx/certs/server.pem"
+    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
     cacertfile = "/etc/emqx/certs/ca.pem"
+    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    certfile = "/etc/emqx/certs/server.pem"
+    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+    keyfile = "/etc/emqx/certs/server.key"
+    # Must verify peer certificats
     verify = verify_peer
+    # Also verify client certificate's revocation status
     enable_crl_check = true
   }
 }

--- a/en_US/network/emqx-mqtt-tls.md
+++ b/en_US/network/emqx-mqtt-tls.md
@@ -87,6 +87,8 @@ You can also enable the SSL/TLS connection by modifying the `listeners.ssl.defau
         # password = "123456"
         # Set 'verify_peer' to verify the authenticity of the client certificates.
         verify = verify_none
+        # If set to true, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the client sends an invalid certificate (an empty certificate is considered valid).
+        fail_if_no_peer_cert = false
       }
     }
    ```

--- a/en_US/network/emqx-mqtt-tls.md
+++ b/en_US/network/emqx-mqtt-tls.md
@@ -77,14 +77,15 @@ You can also enable the SSL/TLS connection by modifying the `listeners.ssl.defau
    listeners.ssl.default {
       bind = "0.0.0.0:8883"
       ssl_options {
-        cacertfile = "etc/certs/rootCA.crt"
-   
-        certfile = "etc/certs/server.crt"
-        keyfile = "etc/certs/server.key"
+        # PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+        cacertfile = "etc/certs/rootCAs.pem"
+        # PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+        certfile = "etc/certs/server-cert.pem"
+        # PEM file containing the private key corresponding to the SSL/TLS certificate.
+        keyfile = "etc/certs/server-key.pem"
         # Enter the password when the private key file is password protected
         # password = "123456"
-   
-        # One-way authentication, peer verification not enabled
+        # Set 'verify_peer' to verify the authenticity of the client certificates.
         verify = verify_none
       }
     }
@@ -92,7 +93,7 @@ You can also enable the SSL/TLS connection by modifying the `listeners.ssl.defau
 
 4. Restart EMQX to apply the configuration.
 
-## Test Client Connection with One-way Authentication 
+## Test Client Connection with One-way Authentication
 
 You can use [MQTTX CLI](https://mqttx.app/) for testing. One-way authentication typically requires the client to provide a CA certificate, so the client can verify the server's identity:
 

--- a/en_US/network/overview.md
+++ b/en_US/network/overview.md
@@ -35,13 +35,13 @@ authentication {
 
   ssl {
     enable = true
-    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
+    # PEM format file containing the trusted CA (certificate authority) certificates that the HTTP client uses to verify the authenticity of the HTTP server.
     cacertfile = "etc/certs/cacert.pem"
-    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    # PEM format file containing the SSL/TLS certificate chain for the HTTP client to send. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     certfile = "etc/certs/cert.pem"
-    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+    # PEM format file containing the private key corresponding to the certificate
     keyfile = "etc/certs/key.pem"
-    ## Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'
+    ## Set 'verify_peer' to verify the authenticity of the server's certificate chain, otherwise 'verify_none'
     verify = verify_peer
   }
 }

--- a/en_US/network/overview.md
+++ b/en_US/network/overview.md
@@ -6,7 +6,7 @@ EMQX adopts SSL and TLS cryptographic protocols to ensure secure network communi
 
 - Establishing a connection between MQTT clients and EMQX
 - Connecting to external resources, such as a database
-- Different EMQX nodes in a cluster communicate with each other 
+- Different EMQX nodes in a cluster communicate with each other
 
 EMQX provides comprehensive support for SSL/TLS capabilities, including support for one-way/two-way authentication and X.509 certificate authentication.
 
@@ -35,10 +35,13 @@ authentication {
 
   ssl {
     enable = true
+    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
     cacertfile = "etc/certs/cacert.pem"
+    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     certfile = "etc/certs/cert.pem"
+    # PEM format file containing the private key corresponding to the SSL/TLS certificate
     keyfile = "etc/certs/key.pem"
-    ## `verify_peer` means turn on verification for server certificate
+    ## Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'
     verify = verify_peer
   }
 }
@@ -47,18 +50,3 @@ authentication {
 ## TLS for Nodes Communication
 
 Instructions on how to enable SSL/TLS for cluster connections are not covered in this chapter, and you can refer to [Cluster Security](../deploy/cluster/security.md) for details.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/zh_CN/configuration/cluster.md
+++ b/zh_CN/configuration/cluster.md
@@ -58,9 +58,9 @@ Where,
 | `core_nodes`             | This sets the core nodes that this replicant code will connect to.<br />Multiple nodes can be added here, separated with a `,` | --            | --                                                |
 | `driver`                 | This sets the transport protocol for inter-EMQX node communication. | `tcp`         | `tcp`, `SSL`                                      |
 | `ssl_options`            | This sets the SSL/TLS configuration options for the listener, it has three properties | --            | --                                                |
-| `ssl_options.cacertfile` | This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates. | --            | --                                                |
-| `ssl_options.certfile`   | This sets the path to the file containing the SSL/TLS certificate for the listener. | --            | --                                                |
-| `ssl_options.keyfile`    | This sets the path to the file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
+| `ssl_options.cacertfile` | PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the peer nodes' certificates. | --            | --                                                |
+| `ssl_options.certfile`   | PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the server certificate to form a chain. | --            | --                                                |
+| `ssl_options.keyfile`    | PEM file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
 
 {% emqxce %}
 

--- a/zh_CN/configuration/cluster.md
+++ b/zh_CN/configuration/cluster.md
@@ -61,7 +61,7 @@ Where,
 | `ssl_options.cacertfile` | PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the peer nodes' certificates. | --            | --                                                |
 | `ssl_options.certfile`   | PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the server certificate to form a chain. | --            | --                                                |
 | `ssl_options.keyfile`    | PEM file containing the private key corresponding to the SSL/TLS certificate. | --            | --                                                |
-
+| `ssl_options.fail_if_no_peer_cert` | If set to true, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the client sends an invalid certificate (an empty certificate is considered valid). | --            | --     |
 {% emqxce %}
 
 :::tip

--- a/zh_CN/configuration/dashboard.md
+++ b/zh_CN/configuration/dashboard.md
@@ -23,9 +23,9 @@ Where,
 - `bind  =  "0.0.0.0:18083"`  is to set the network address and port number that the listener will bind to. In this case, the listener will bind to all available network interfaces (`0.0.0.0`) on port `18083`.
 - `max_connections  =  512` is to set the maximum number of concurrent connections that the listener will accept. In this case, the maximum number of connections is set to `512`.
 - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-  - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-  - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-  - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+  - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+  - `certfile`: PEM the file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+  - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
 {% emqxce %}
 

--- a/zh_CN/configuration/listener.md
+++ b/zh_CN/configuration/listener.md
@@ -57,7 +57,8 @@ where:
     - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
     - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener.  If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
-
+    - `verify`:  Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'.
+    - `fail_if_no_peer_cert`: If set to true, the server fails if the client does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the client sends an invalid certificate (an empty certificate is considered valid).
 
 ## Configure WebSocket Listener
 

--- a/zh_CN/configuration/listener.md
+++ b/zh_CN/configuration/listener.md
@@ -54,11 +54,10 @@ where:
   - `bind` is the IP address and port of the listener, here it will listen to all incoming traffic from any IP address on port `8883`. 
   - `max_connection` is the maximum number of concurrent connections allowed by the listener, default value: `infinity`.
   - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-    - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-    - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-    - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+    - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+    - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener.  If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
- 
 
 ## Configure WebSocket Listener
 
@@ -111,9 +110,9 @@ where:
   - `max_connection` is the maximum number of concurrent connections allowed by the listener, default value: `infinity`.
   - `websocket.mqtt_path` is to set the path to the WebSocket’s MQTT protocol, which is `/mqtt` by default. 
     - `ssl_options` is the SSL/TLS configuration option for the listener, it has three properties:
-      - `cacertfile`: This sets the path to the file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
-      - `certfile`: This sets the path to the file containing the SSL/TLS certificate for the listener.
-      - `keyfile`: This sets the path to the file containing the private key corresponding to the SSL/TLS certificate.
+      - `cacertfile`: PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+      - `certfile`: PEM file containing the SSL/TLS certificate for chain the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+      - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
 
 

--- a/zh_CN/deploy/cluster/security.md
+++ b/zh_CN/deploy/cluster/security.md
@@ -62,6 +62,11 @@ rpc {
   certfile = "/path/to/cert/domain.pem"
   # PEM format file containing the private key corresponding to the SSL/TLS certificate
   keyfile = "/path/to/cert/domain.key"
+  # Set to 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'.
+  verify = verify_peer
+  # If set to true, the handshake fails if the peer does not have a certificate to send, that is, sends an empty certificate. If set to false, it fails only if the peer sends an invalid certificate (an empty certificate is considered valid).
+  fail_if_no_peer_cert = true
+
 }
 ```
 

--- a/zh_CN/deploy/cluster/security.md
+++ b/zh_CN/deploy/cluster/security.md
@@ -56,9 +56,12 @@ TLS 是以增加 CPU 负载和 RAM 使用为代价的。
 ```
 rpc {
   driver = ssl
-  certfile = /path/to/cert/domain.pem
-  cacertfile = /path/to/cert/ca.pem
-  keyfile = /path/to/cert/domain.key
+  # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the cluster peers.
+  cacertfile = "/path/to/cert/ca.pem"
+  # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+  certfile = "/path/to/cert/domain.pem"
+  # PEM format file containing the private key corresponding to the SSL/TLS certificate
+  keyfile = "/path/to/cert/domain.key"
 }
 ```
 

--- a/zh_CN/network/crl.md
+++ b/zh_CN/network/crl.md
@@ -40,6 +40,8 @@ listeners.ssl.default {
     keyfile = "/etc/emqx/certs/server.key"
     # Must verify peer certificats
     verify = verify_peer
+    # Force the client to send a non-empty certificate, otherwise fail the TLS handshake.
+    fail_if_no_peer_cert = true
     # Also verify client certificate's revocation status
     enable_crl_check = true
   }

--- a/zh_CN/network/crl.md
+++ b/zh_CN/network/crl.md
@@ -32,10 +32,15 @@ listeners.ssl.default {
   bind = "0.0.0.0:8883"
   max_connections = 512000
   ssl_options {
-    keyfile = "/etc/emqx/certs/server.key"
-    certfile = "/etc/emqx/certs/server.pem"
+    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
     cacertfile = "/etc/emqx/certs/ca.pem"
+    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    certfile = "/etc/emqx/certs/server.pem"
+    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+    keyfile = "/etc/emqx/certs/server.key"
+    # Must verify peer certificats
     verify = verify_peer
+    # Also verify client certificate's revocation status
     enable_crl_check = true
   }
 }

--- a/zh_CN/network/emqx-mqtt-tls.md
+++ b/zh_CN/network/emqx-mqtt-tls.md
@@ -72,10 +72,12 @@ EMQX 默认在 `8883` 端口启用了 SSL/TLS 监听器并设置其为单向认�
     listeners.ssl.default {
       bind = "0.0.0.0:8883"
       ssl_options {
-        cacertfile = "etc/certs/rootCA.crt"
-
-        certfile = "etc/certs/server.crt"
-        keyfile = "etc/certs/server.key"
+        # PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+        cacertfile = "etc/certs/rootCAs.pem"
+        # PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+        certfile = "etc/certs/server-cert.pem"
+        # PEM file containing the private key corresponding to the SSL/TLS certificate.
+        keyfile = "etc/certs/server-keyi.pem"
         # 私钥文件受密码保护时需要输入密码
         # password = "123456"
 

--- a/zh_CN/network/emqx-mqtt-tls.md
+++ b/zh_CN/network/emqx-mqtt-tls.md
@@ -72,17 +72,18 @@ EMQX 默认在 `8883` 端口启用了 SSL/TLS 监听器并设置其为单向认�
     listeners.ssl.default {
       bind = "0.0.0.0:8883"
       ssl_options {
-        # PEM file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the client certificates.
+        # PEM 格式的文件，包含一个或多个用于验证客户端证书的根 CA 证书
         cacertfile = "etc/certs/rootCAs.pem"
-        # PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+        # PEM 格式的服务器证书，如果证书不是直接由根 CA 签发，那么中间 CA 的证书必须加在服务器证书的后面组成一个证书链
         certfile = "etc/certs/server-cert.pem"
-        # PEM file containing the private key corresponding to the SSL/TLS certificate.
+        # PEM 格式的密钥文件
         keyfile = "etc/certs/server-keyi.pem"
         # 私钥文件受密码保护时需要输入密码
         # password = "123456"
-
-        # 单向认证，不验证客户端证书
+        # 设置成 'verify_peer' 来验证客户端证书是否为 cacertfile 中某个根证书签发
         verify = verify_none
+        # 如果设置成 true，但是客户端在握手时候没有发送证书，服务端会终止握手，如果设置成 false，那么服务端只有在客户端发送一个非法证书时才会终止握手
+        fail_if_no_peer_cert = false
       }
     }
    ```

--- a/zh_CN/network/overview.md
+++ b/zh_CN/network/overview.md
@@ -45,14 +45,14 @@ authentication {
 
   ssl {
     enable = true
-    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
+    # PEM 格式的文件，包含一个或多个用于验证 HTTP 服务器证书的根 CA 证书
     cacertfile = "etc/certs/cacert.pem"
-    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+    # PEM 格式的客户端证书，如果证书不是直接由根 CA 签发，那么中间 CA 的证书必须加在服务器证书的后面组成一个证书链
     certfile = "etc/certs/cert.pem"
-    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+    # PEM 格式的密钥文件
     keyfile = "etc/certs/key.pem"
-    ## Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'
-    verify = verify_peer
+    # 设置成 'verify_peer' 来验证 HTTP 服务器端证书是否为 cacertfile 中某个根证书签发
+    verify = verify_none
   }
 }
 ```

--- a/zh_CN/network/overview.md
+++ b/zh_CN/network/overview.md
@@ -45,10 +45,13 @@ authentication {
 
   ssl {
     enable = true
+    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
     cacertfile = "etc/certs/cacert.pem"
+    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
     certfile = "etc/certs/cert.pem"
+    # PEM format file containing the private key corresponding to the SSL/TLS certificate
     keyfile = "etc/certs/key.pem"
-    ## `verify_peer` means turn on verification for server certificate
+    ## Set 'verify_peer' to verify the authenticity of the clients' certificates, otherwise 'verify_none'
     verify = verify_peer
   }
 }


### PR DESCRIPTION
Some important information must be included:
* The files should be of PEM format
* The certfile must be a chain, but not just the server cert.