### PR TITLE
docs: improve dashboard listener config example

### DIFF
--- a/en_US/configuration/dashboard.md
+++ b/en_US/configuration/dashboard.md
@@ -14,19 +14,32 @@ For example, to configure `swagger_support` and a listener for the EMQX Dashboar
 dashboard {
   listeners {
     http {
+      # set 'bind = 0' will disable this listener
       bind = "0.0.0.0:18083"
       max_connections = 512
     }
-  swagger_support = true
+    https {
+      # set 'bind = 0' will disable this listener
+      bind = "0.0.0.0:18084"
+      ssl_options {
+        certfile = "${EMQX_ETC_DIR}/certs/cert.pem"
+        keyfile = "${EMQX_ETC_DIR}/certs/key.pem"
+      }
+    }
   }
+  swagger_support = true
+  default_password = jEdOgGS6vzQ
 }
 ```
 
 Where,
 
-- `swagger_support  =  true` is to enable all swagger-related features such as generating the Swagger API documentation. By default, its value is always `true`, and you can set the value to `false` to disable it.
-- `bind  =  "0.0.0.0:18083"`  is to set the network address and port number that the listener will bind to. In this case, the listener will bind to all available network interfaces (`0.0.0.0`) on port `18083`.
-- `max_connections  =  512` is to set the maximum number of concurrent connections that the listener will accept. In this case, the maximum number of connections is set to `512`.
+- `swagger_support = true`: Enable Swagger (OpenAPI) UI available at the endpoint `/api-docs`. Set to `false` to disable.
+- `bind = "0.0.0.0:18083"`:  Address and port number that the listener will bind to. In this case, the listener will bind to all available network interfaces (`0.0.0.0`) on port `18083`. set to port number `0` will disable this listener.
+- `max_connections = 512`: Set the maximum number of concurrent connections that the listener will accept. In this case, the maximum number of connections is set to `512`.
+- `ssl_options.certfile`: Path to the PEM format certificates chain file. Server certificate as the first one, followed by its immediate issuer certificate then the issuer's issuer certificate, and so on. Root CA certificate is optional. The path prefix (only prefix) can be an environment variable.
+- `ssl_options.keyfile`: Path to the PEM format private key file.
+- `default_password`: The password used to **initialize** the database record for `admin` user. NOTE: Changing this config after EMQX has booted for the first time has no effect. Once initialized, the default password `public` (which comes with the installation) must be changed from dashboard or CLI.
 
 {% emqxce %}
 

--- a/zh_CN/configuration/dashboard.md
+++ b/zh_CN/configuration/dashboard.md
@@ -17,8 +17,17 @@ dashboard {
       bind = "0.0.0.0:18083"
       max_connections = 512
     }
-  swagger_support = true
+    https {
+      # set 'bind = 0' will disable this listener
+      bind = "0.0.0.0:18084"
+      ssl_options {
+        certfile = "${EMQX_ETC_DIR}/certs/cert.pem"
+        keyfile = "${EMQX_ETC_DIR}/certs/key.pem"
+      }
+    }
   }
+  swagger_support = true
+  default_password = jEdOgGS6vzQ
 }
 ```
 
@@ -27,6 +36,9 @@ dashboard {
 - `swagger_support = true` 用于启用所有与 swagger 相关的功能，如生成Swagger API文档。默认情况下，其值始终为 `true`，您可以将值设置为 `false` 以禁用它。
 - `bind = "0.0.0.0:18083"` 用于设置监听器绑定的网络地址和端口号。在这种情况下，监听器将绑定到所有可用的网络接口（`0.0.0.0`）上的端口 `18083`。
 - `max_connections = 512` 用于设置监听器将接受的最大并发连接数。在这种情况下，最大连接数设置为 `512`。
+- `ssl_options.certfile`: 指向包含 PEM 格式证书的文件。文件中第一个证书必须是服务器证书，紧接着是签发这个证书的中间 CA 证书，依次罗列到根 CA 证书为止。（根 CA 证书可选）。
+- `ssl_options.keyfile`: 指向包含 PEM 格式的私钥文件。
+- `default_password`: 用于为 `admin` 用户初始化数据库条目的默认密码。注意：一旦 EMQX 初次启动成功，修改这个密码将不再不起作用。初始化后，密码必须在控制台或者命令行进行修改。
 
 {% emqxce %}
 


### PR DESCRIPTION
- swagger_support was added at the wrong level.
- it was not quite clear how to enable https listener, so added to the example config.
- listed the most important configs for https lister: certificates.