### PR TITLE
fix: connect command in mongo container

### DIFF
--- a/en_US/data-integration/data-bridge-mongodb.md
+++ b/en_US/data-integration/data-bridge-mongodb.md
@@ -138,8 +138,8 @@ docker run -d --name mongodb -p 27017:27017 mongo
 # Access the container
 docker exec -it mongodb bash
 
-# Locate the MongoDB server in the container
-mongo
+# Locate the MongoDB server in the container (use `mongo` with 4.x versions)
+mongosh
 
 # Create a user
 use admin

--- a/zh_CN/data-integration/data-bridge-mongodb.md
+++ b/zh_CN/data-integration/data-bridge-mongodb.md
@@ -138,8 +138,8 @@ docker run -d --name mongodb -p 27017:27017 mongo
 # 进入容器
 docker exec -it mongodb bash
 
-# 在容器中连接到 MongoDB 服务器，
-mongo
+# 在容器中连接到 MongoDB 服务器（4.x 版本请使用命令 `mongo`）
+mongosh
 
 # 创建用户
 use admin


### PR DESCRIPTION
[Docker Official Image / Mongo](https://hub.docker.com/_/mongo#:~:text=runs%20the%20mongosh%20(use%20mongo%20with%204.x%20versions))

> The MongoDB server in the image listens on the standard MongoDB port, 27017, so connecting via Docker networks will be the same as connecting to a remote mongod. The following example starts another MongoDB container instance and runs the `mongosh` (use `mongo` with `4.x` versions) command line client against the original MongoDB container from the example above, allowing you to execute MongoDB statements against your database instance: