### PR TITLE
Fix durability section

### DIFF
--- a/en_US/durability/durability_introduction.md
+++ b/en_US/durability/durability_introduction.md
@@ -16,9 +16,9 @@ Before learning the durable sessions feature in EMQX, it's essential to first un
 
 ### Sessions and Durable Storages
 
-**Session** is a lightweight process within EMQX that is created for every client connection. Sessions implement the behaviors prescribed to the broker by the MQTT Standard, including initial connection, subscribing and unsubscribing to topics, and message dispatching.
+**Session** is a lightweight process within EMQX that is created for every client connection. Sessions implement behaviors prescribed to the broker by MQTT Standard, including initial connection, subscribing and unsubscribing to topics, and message dispatching.
 
-**Durable Storage** is an internal database within EMQX. Sessions may use it to save their state, as well as MQTT messages sent to the topics. Database engine powering durable storages uses [RocksDB](https://rocksdb.org/) to save the data on disk, and [Raft](https://raft.github.io/) to consistently replicate the data across the cluster. Durable storages should not be confused with the **Durable Sessions**.
+**Durable Storage** is an internal database within EMQX. Sessions may use it to save their state as well as MQTT messages sent to the topics. Database engine powering durable storages uses [RocksDB](https://rocksdb.org/) to save the data on disk, and [Raft](https://raft.github.io/) to consistently replicate the data across the cluster. Durable storages should not be confused with the **Durable Sessions**.
 
 ### Session Expiry Interval
 
@@ -64,7 +64,7 @@ However, there are some drawbacks:
 
 - Session data is lost when the EMQX node hosting the session stops or restarts.
 - Undelivered messages are stored in the session's memory queue, increasing memory footprint of the broker.
-- EMQX imposes a limit on the size of the memory queue to prevent memory exhaustion. New messages are discarded when this limit is reached, leading to potential message loss of undelivered messages.
+- EMQX imposes a limit on the size of the memory queue to prevent memory exhaustion. New messages are discarded when this limit is reached, leading to potential loss of undelivered messages.
 
 #### Durable Sessions
 

--- a/en_US/durability/durability_introduction.md
+++ b/en_US/durability/durability_introduction.md
@@ -1,6 +1,6 @@
 # MQTT Durable Sessions
 
-EMQX includes a built-in durable sessions feature, which allows MQTT sessions and messages to be persistently stored on disk, providing high availability replicas to ensure data redundancy and consistency. With session persistence, effective failover and recovery mechanisms can be implemented, ensuring service continuity and availability, thereby improving system reliability.
+EMQX includes a built-in durable sessions feature, which allows MQTT sessions and messages to be persistently stored on disk, providing high availability replicas to ensure data redundancy and consistency. With session durability, effective failover and recovery mechanisms can be implemented, ensuring service continuity and availability, thereby improving system reliability.
 
 This page introduces the concepts, principles, and usage of session persistence in EMQX.
 
@@ -12,57 +12,50 @@ This feature is available starting from EMQX v5.7.0. However, it does not yet su
 
 ## Basic Concepts
 
-Before learning the durable sessions feature in EMQX, it's essential to first understand some basic concepts about MQTT sessions.
+Before learning the durable sessions feature in EMQX, it's essential to first understand some basic concepts about EMQX.
+
+### Sessions and Durable Storages
+
+**Session** is a process within EMQX that is created for every client connection. Sessions implement the behaviors prescribed to the broker by the MQTT Standard, including initial connection, subscribing and unsubscribing to the topics, and message dispatching.
+
+**Durable Storage** is an internal database within EMQX. Sessions use it to store their state, as well as MQTT messages sent to the topics. Database engine powering the durable storages uses [RocksDB](https://rocksdb.org/) to save the data on disk, and [Raft](https://raft.github.io/) to consistently replicate the data across the cluster. Durable storages should not be confused with the **Durable Sessions**.
 
 ### Types of Client Sessions
 
-The durable sessions in EMQX only applies to persistent sessions, so it's necessary to first understand the categorization of MQTT client sessions.
-
 According to the MQTT standard, client sessions facilitate the management of client connections and states within the MQTT broker. Informally, EMQX separates client sessions into 2 logical categories:
 
-- **Persistent Sessions**: Persistent sessions are kept by the broker after the client's connection terminates, and can be resumed if the client reconnects to the broker within the session expiry interval. Messages sent to the topics while the client was offline are delivered.
-- **Ephemeral Sessions**: Ephemeral sessions exist only for the duration of the client's connection to EMQX. When a client with an ephemeral session disconnects, all session information, including subscriptions and undelivered messages, is discarded.
+- **Ephemeral Sessions**: Ephemeral sessions exist only for the duration of the client's connection to EMQX. When a client with an ephemeral session disconnects, all session information, including subscriptions and undelivered messages, is immediately discarded.
+- **Non-Ephemeral Sessions**: Sessions that are kept by the broker after the client's connection terminates, and can be resumed if the client reconnects to the broker within the session expiry interval. Messages sent to the topics while the client was offline are delivered.
 
-The client session is considered persistent in following cases:
+The client session is considered non-ephemeral in following cases:
 
 - For the clients using the MQTT 5 protocol, [Session Expiry Interval](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901048) property of `CONNECT` or `DISCONNECT` packet is set to a value greater than zero.
 
 - For the clients using MQTT 3.* protocol, [Clean Session](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030) flag is set to 0, and `mqtt.session_expiry_interval` configuration parameter is set to a value greater than 0.
 
-### Conceptual Differentiation
-
-In the context of MQTT usage, the concepts of Persistent Sessions and Durable Sessions may be easily confused, so this section aims to differentiate between the two.
-
-- **Persistent Sessions**: A feature in the MQTT protocol where a client can choose to maintain its current session when establishing a connection with the server. Even if the client disconnects and reconnects, its previously subscribed topics, unsent messages, and other states are retained. In essence, it pertains to the persistence of client connection states and message queues.
-- **Durable Sessions**: This is an MQTT protocol-independent feature that refers to whether client sessions are saved to persistent storage (disk), ensuring message delivery reliability.
-
 ## Session Storage Implementations in EMQX
 
-EMQX provides 2 different client session storage implementations, each optimized for specific use cases:
+EMQX provides 2 different client session implementations, each optimized for specific use cases:
 
-- **RAM Storage**: Sessions are stored in the memory of the EMQX node, making them non-persistent.
-- **Durable Storage**: Adds a persistence layer, with sessions stored using local RocksDB and the node's local disk in the current version.
+- **Regular sessions**: Sessions that keep their state in the memory of the running EMQX node. Their state is lost when the EMQX node restarts.
+- **Durable sessions**: Sessions that back up their state and received messages in the durable storage. They can be resumed after restart of the EMQX node.
 
-The choice of implementation depends on the session type (ephemeral or persistent) and the `durable_sessions.enable` configuration parameter, which can be set globally or per [zone](../configuration/configuration.md#zone-override). The implementation can be selected based on the following criteria:
+The choice of session implementation depends on the session type (ephemeral or not) and the `durable_sessions.enable` configuration parameter, which can be set globally or per [zone](../configuration/configuration.md#zone-override). The implementation can be selected based on the following criteria:
 
-| `durable_sessions.enable` | Ephemeral Session | Persistent Session |
-| ------------------------- | ----------------- | ------------------ |
-| `false`                   | RAM               | RAM                |
-| `true`                    | RAM               | durable            |
+| `durable_sessions.enable` | Ephemeral | Non-Ephemeral |
+|---------------------------|-----------|---------------|
+| `false`                   | Regular   | Regular       |
+| `true`                    | Regular   | Durable       |
 
-EMQX uses a unique approach to manage message durability, allowing RAM and durable sessions to coexist while minimizing storage costs.
+EMQX uses a unique approach to manage message durability, allowing regular and durable sessions to coexist while minimizing storage costs.
 
-When a durable session subscribes to a topic filter, EMQX marks the topics matching that filter as "durable." This ensures that, in addition to routing MQTT PUBLISH messages from these topics to RAM sessions, the broker also saves these messages to durable storage.
+### Comparison of the Session Implementations
 
-Each durable MQTT message is stored exactly once on each replica, regardless of the number of subscribing durable sessions or their connection status. This efficient fan-out minimizes disk writes.
+The management strategy for client sessions is a crucial factor in ensuring service stability and reliability. This section provides a comparative analysis of the characteristics of the two sessions implementations. It aims to help developers better understand their respective features and applicable scenarios, enabling more precise deployment decisions.
 
-### Comparison of RAM Storage and Durable Storage
+#### Regular Sessions
 
-The management strategy for client sessions is a crucial factor in ensuring service stability and reliability. This section provides a comparative analysis of the characteristics of RAM storage and durable storage for MQTT sessions in EMQX. It aims to help developers better understand their respective features and applicable scenarios, enabling more precise deployment decisions.
-
-#### RAM Storage
-
-The RAM storage implementation is the default and has been used in all EMQX releases before version 5.7. As the name implies, the state of RAM sessions is maintained entirely in volatile memory.
+This session implementation is the default and has been used in all EMQX releases before version 5.7. State of regular sessions is maintained entirely in RAM of the running EMQX node.
 
 Advantages of RAM storage include:
 
@@ -78,17 +71,22 @@ However, there are some drawbacks:
 
 Introduced in EMQX v5.7.0, the durable session implementation stores session state and messages routed to the durable sessions on disk. This feature is disabled by default and can be enabled by setting the `durable_sessions.enable` configuration parameter to `true`.
 
-Durable sessions provide robust durability and high availability by consistently replicating session metadata and MQTT messages across multiple nodes within an EMQX cluster. The configurable [replication factor](./managing-replication.md#replication-factor) determines the number of replicas for each message or session, enabling users to customize the balance between durability and performance to meet their specific requirements.
+When a durable session subscribes to a topic filter, EMQX marks the topics matching that filter as "durable." This ensures that, in addition to routing MQTT PUBLISH messages from these topics to regular sessions, the broker also saves these messages to the durable storage called `messages`.
+It's important to note that the protocol used to dispatch messages depends on the durability of the subscriber rather than the publisher.
 
-Advantages of durable storage include:
+Each durable MQTT message is stored exactly once on each replica, regardless of the number of subscribing durable sessions or their connection status. This ensures efficient message fan-out and minimizes disk writes.
+
+Durable storage provides robust durability and high availability by consistently replicating session metadata and MQTT messages across multiple nodes within an EMQX cluster. The configurable [replication factor](./managing-replication.md#replication-factor) determines the number of replicas for each message or session, enabling users to customize the balance between durability and performance to meet their specific requirements.
+
+Advantages of durable sessions include:
 
 - Sessions can be resumed after EMQX nodes are restarted or stopped.
-- MQTT messages are stored in a shared, replicated, durable storage instead of a memory queue, reducing RAM usage for both online and offline sessions.
+- MQTT messages are stored in a shared, replicated, durable storage instead of a memory queue, reducing RAM usage for both online and offline sessions. There is no upper limit on the number of undelivered messages, undelivered messages are never discarded due to memory queue overrun.
 
 However, there are some disadvantages:
 
 - Storing messages on disk results in lower overall system throughput.
-- Durable sessions have higher latency compared to RAM sessions because both writing and reading MQTT messages are performed in batches. While batching improves throughput, it also increases end-to-end latency (the delay before clients see the published messages).
+- Durable sessions have higher latency compared to regular sessions because both writing and reading MQTT messages are performed in batches. While batching improves throughput, it also increases end-to-end latency (the delay before clients see the published messages).
 
 ## Quick Start with Durable Sessions
 
@@ -117,7 +115,7 @@ Even if durable sessions are not enabled, following steps 2-4 will still retain 
    Using [MQTTX CLI](https://mqttx.app/cli) as an example, which defaults to using MQTT 5.0 protocol, add the `--no-clean` option to set `Clean Start = false`, and specify the client ID as `emqx_c`. Connect to EMQX and subscribe to the `t/1` topic:
 
    ```bash
-   mqttx sub -t t/1 -i emqx_c --no-clean
+   mqttx sub -se 60 -t t/1 -i emqx_c --no-clean
    ```
 
 3. Disconnect the client, and the session will be retained.
@@ -143,7 +141,7 @@ Even if durable sessions are not enabled, following steps 2-4 will still retain 
    Try connecting to EMQX with the same client ID `emqx_c` and using the `--no-clean` option to set `Clean Start = false`:
 
    ```bash
-   mqttx sub -t t/1 -i emqx_c --no-clean
+   mqttx sub -se 60 -t t/1 -i emqx_c --no-clean
    ```
 
    The messages received during the offline period will be delivered to the current client:
@@ -165,9 +163,9 @@ Even if durable sessions are not enabled, following steps 2-4 will still retain 
 
    :::
 
-## Durable Sessions Architecture
+## Durable Storage Architecture
 
-EMQX's durable sessions is organized into a hierarchical structure comprising storages, shards, generations, and streams.
+The database engine powering EMQX's builtin durability facilities organizes data into a hierarchical structure comprising storages, shards, generations, and streams.
 
 ![Diagram of EMQX durable storage sharding](./assets/emqx_ds_sharding.png)
 
@@ -193,17 +191,17 @@ Messages in each shard and generation are split into streams. Streams serve as u
 
 Durable sessions fetch messages in batches from the streams, with batch size adjustable via the `durable_sessions.batch_size` parameter.
 
-## Durable Sessions Across Cluster
+## Durable Storages Across Cluster
 
 Each node within an EMQX cluster is assigned a unique *Site ID*, which serves as a stable identifier, independent of the Erlang node name (`emqx@...`). Site IDs are persistent, and they are randomly generated at the first startup of the node. This stability maintains the integrity of the data, especially in scenarios where nodes might undergo name modifications or reconfigurations.
 
-Administrators can manage and monitor durable sessions across the cluster by using the `emqx_ctl ds info` CLI command to view the status of different sites.
+Administrators can manage and monitor durable storage status across the cluster by using the `emqx_ctl ds info` CLI command to view the status of different sites.
 
 ## Hardware Requirements for Session Persistence
 
-When session persistence is enabled, EMQX saves the metadata of persistent sessions and MQTT messages sent to the persistent sessions on disk. Therefore, EMQX must be deployed on a server with sufficiently large storage capacity. To achieve the best throughput, it is recommended to use Solid State Drive (SSD) storage.
+When session durability is enabled, EMQX saves the metadata of durable sessions and MQTT messages sent to the durable sessions on disk. Therefore, EMQX must be deployed on a server with sufficiently large storage capacity. To achieve the best throughput, it is recommended to use Solid State Drive (SSD) storage.
 
-The storage requirements can be estimated according to the following guidelines:
+The disk space requirements can be estimated according to the following guidelines:
 
 - **Message Storage**: The space required for storing messages on each replica is proportional to the rate of incoming messages multiplied by the duration specified by the `durable_sessions.message_retention_period` parameter. This parameter dictates how long messages are retained, influencing the total storage needed.
 - **Session Metadata Storage**: The amount of storage for session metadata is proportional to the number of sessions multiplied by the number of streams to which they are subscribed.

--- a/en_US/durability/management.md
+++ b/en_US/durability/management.md
@@ -16,7 +16,7 @@ Configuration for durable sessions is divided into 2 main categories:
 | `durable_sessions.enable`                   | Enables session durability. Note: Restart of the EMQX node is required for changes to take effect. |
 | `durable_sessions.batch_size`               | Controls the maximum size of message batches consumed from the storage by durable sessions. |
 | `durable_sessions.idle_poll_interval`       | Controls the frequency of querying the storage for new messages by durable sessions. If new messages are found, the next batch is retrieved immediately if the client's in-flight queue has space. |
-| `durable_sessions.heartbeat_interval`       | Specifies the interval for saving session metadata to the durable sessions. |
+| `durable_sessions.heartbeat_interval`       | Specifies the interval for saving session metadata. |
 | `durable_sessions.renew_streams_interval`   | Defines how often sessions query the storage for new streams. |
 | `durable_sessions.session_gc_interval`      | Specifies the interval for sweeping through sessions and deleting expired ones. |
 | `durable_sessions.message_retention_period` | Defines the retention period of MQTT messages in durable sessions. Note: this parameter is global. |
@@ -31,7 +31,7 @@ The following parameters can be overridden per [zone](../configuration/configura
 
 ### Durable Storage Configuration
 
-The `<DS>` placeholder stands for "durable storage".  Currently, the available parameter for `<DS>` is `message`.
+The `<DS>` placeholder stands for "durable storage".  Currently, the available parameter for `<DS>` is `messages`.
 
 | Parameter                                 | Description                                                  |
 | ----------------------------------------- | ------------------------------------------------------------ |
@@ -252,4 +252,3 @@ A rolling average of time (in μs) spent consuming a batch of messages from dura
 These counters are specific to the "wildcard optimized" storage layout. They measure the efficiency of consuming data from local storage. The `seek` primitive is generally slower, so the rate of `emqx_ds_storage_bitfield_lts_counter_next` should ideally grow faster than `seek`.
 
 Increasing the `durable_storage.messages.layout.epoch_bits` parameter can help improve this ratio.
-

--- a/en_US/durability/managing-replication.md
+++ b/en_US/durability/managing-replication.md
@@ -20,18 +20,18 @@ In smaller clusters, the replication factor is not strictly enforced. For instan
 
 ### Number of Shards
 
-The built-in durable sessions are split into shards, which are replicated independently from each other.
-A higher number of shards allows for more parallel publishing and consuming of MQTT messages from the durable sessions. However, each shard consumes system resources, such as file descriptors, and increases the volume of metadata stored per session.
+The built-in durable storages are split into shards, which are replicated independently from each other.
+A higher number of shards allows for more parallel publishing and consuming of MQTT messages. However, each shard consumes system resources, such as file descriptors, and increases the volume of metadata stored per session.
 
 The `durable_storage.messages.n_shards` parameter controls the number of shards, which remains fixed once the durable sessions is initialized.
 
 ### Number of Sites
 
-The `durable_storage.messages.n_sites` configuration parameter determines the minimum number of sites that must be online for the durable sessions to initialize and start accepting writes. Once this minimum is met, the durable sessions begins allocating shards to the available sites in a balanced manner.
+The `durable_storage.messages.n_sites` configuration parameter determines the minimum number of sites that must be online for the durable storage to initialize and start accepting writes. Once this minimum is met, the durable storages begins allocating shards to the available sites in a balanced manner.
 
 The default value is `1`, meaning each node may initially consider itself the sole site responsible for data storage. This setup is optimized for single-node EMQX clusters. When the cluster forms, one node's view will eventually dominate, causing other nodes to abandon their stored data.
 
-In multi-node clusters, it is recommended to set the number of sites to the initial cluster size to prevent such conflicts. Note that once the durable sessions is initialized, this parameter cannot be changed.
+In multi-node clusters, it is recommended to set the number of sites to the initial cluster size to prevent such conflicts. Note that once the durable storage is initialized, this parameter cannot be changed.
 
 ## Change Existing Cluster
 
@@ -49,15 +49,15 @@ SHARDS:
 
 ### Add Sites
 
-When a new node joins the cluster, it is assigned a *Site ID* and can be included in the durable sessions. Some shard replica responsibilities will be transferred to the new site, which will then start replicating the data.
+When a new node joins the cluster, it is assigned a *Site ID* and can be included in the durable storage. Some shard replica responsibilities will be transferred to the new site, which will then start replicating the data.
 ```shell
 $ emqx ctl ds join messages <Site ID>
 ok
 ```
 
-Depending on the cluster's data volume, joining a new site may take some time. While this process does not compromise the availability of durable sessions, it may temporarily affect cluster performance due to the background data transfer between sites.
+Depending on the cluster's data volume, joining a new site may take some time. While this process does not compromise the availability of durable storages, it may temporarily affect cluster performance due to the background data transfer between sites.
 
-Changes to the set of durable sessions sites are durably stored, ensuring that node restarts or network partitions do not affect the outcome. The cluster will eventually achieve the desired state consistently.
+Changes to the replica set are durably stored, ensuring that node restarts or network partitions do not affect the outcome. The cluster will eventually achieve the desired state consistently.
 
 ### Remove Sites
 
@@ -71,7 +71,7 @@ Removing a site can cause the effective replication factor to drop below the con
 
 ### Assign Sites
 
-A series of changes to the set of sites holding durable sessions replicas can be performed in a single operation.
+A series of changes to the set of sites holding durable storage replicas can be performed in a single operation.
 ```shell
 $ emqx ctl ds set_replicas messages <Site ID 1> <Site ID 2> ...
 ```


### PR DESCRIPTION
This PR restores the meaning of terms in the documentation for the durable storage feature.  

- It fixes the mixup between "sessions" and "storages" and adds a short section explaining the difference between these two concepts.
- It removes unnecessary categorization of sessions into "persistent" and "ephemeral". Now the document simply talks about session expiry interval, which is part of MQTT standard and as such doesn't need a lengthy introduction. 
- It also replaces term "RAM session" with "Regular sessions" to avoid any terminology overlap with the future "RAM cache" feature. "Regular sessions" is not the best term, but they are not the focus of the document, so it helps to get them out of the way. Users already familiar with EMQX should have good intuition what it means.

In summary, I removed most of unnecessary terminology to focus attention on the subject matter.