### PR TITLE
fix(mqtt config): Update Keep Alive Settings

### DIFF
--- a/en_US/configuration/mqtt.md
+++ b/en_US/configuration/mqtt.md
@@ -94,17 +94,17 @@ Where,
 
 ## Keep Alive Settings
 
-Keep Alive is the mechanism that ensures that a connection between an MQTT client and EMQX remains active even if no data is transmitted. This is how it works: when an MQTT client creates a connection to EMQX, it can set the Keep Alive variable header field in the connection request protocol packet to a non-zero value. For details about how Keep Alive works, see [What is the MQTT Keep Alive parameter for?](https://www.emqx.com/en/blog/mqtt-keep-alive)
+The Keep Alive is a Two Byte Integer, a time interval measured in seconds. It is a mechanism to ensure that an MQTT client and EMQX connection remain active even if no data is transmitted. When an MQTT client establishes a connection with EMQX, setting a non-zero value in the Keep Alive variable header field of the CONNECT packet can enable the Keep Alive mechanism between both parties. For details about how Keep Alive works, see [What is the MQTT Keep Alive parameter for?](https://www.emqx.com/en/blog/mqtt-keep-alive).
 
-For clients with Keep Alive enabled, you can continue to customize the coefficient EMQX uses to confirm whether the keep alive duration of the client expires.
+According to the MQTT 5.0 protocol, for clients with Keep Alive enabled, if the server does not receive an MQTT Control Packet from the client within 1.5 times the Keep Alive duration, it must close the network connection with the client. Therefore, EMQX introduces a configuration option `keepalive_multiplier` to periodically check clients' Keep Alive timeout status. The default value for `keepalive_multiplier` is `1.5`:
 
 ```bash
-keepalive_backoff = 0.75
+keepalive_multiplier = 1.5
 ```
 
-Where, **Keep Alive Backoff** (`keepalive_backoff`) is the coefficient EMQX uses to confirm whether the keep alive duration of the client expires. Default: `0.75`. The calculation formular is as follows:
+The timeout calculation formula is as follows: 
 $$
-Keep Alive * Backoff * 2
+\text{Keep Alive} \times \text{keepalive\_multiplier}
 $$
 
 ## Session Settings


### PR DESCRIPTION
Need to delete the old `keepalive_backoff` config and add `keepalive_multiplier`.

[#10702](https://github.com/emqx/emqx/pull/10702) Introduced a more straightforward configuration option keepalive_multiplier and deprecate the old keepalive_backoff configuration. After this enhancement, EMQX checks the client's keepalive timeout status period by multiplying the "Client Requested Keepalive Interval" with keepalive_multiplier.

This [blog](https://www.emqx.com/en/blog/mqtt-keep-alive) also needs to be updated to reflect the change/enhancement