### PR TITLE
Temporarily change api "zh" doc links to "en"

### DIFF
--- a/dir.yaml
+++ b/dir.yaml
@@ -190,7 +190,7 @@
         - title_en: EMQX 企业版 API 文档
           title_cn: EMQX 企业版 API 文档
           lang: cn
-          path: https://docs.emqx.com/zh/enterprise/v${EE_MINOR_VERSION}/admin/api-docs.html
+          path: https://docs.emqx.com/en/enterprise/v${EE_MINOR_VERSION}/admin/api-docs.html
         - title_en: EMQX Open Source API Docs
           title_cn: EMQX Open Source API Docs
           lang: en
@@ -198,7 +198,7 @@
         - title_en: EMQX 开源版 API 文档
           title_cn: EMQX 开源版 API 文档
           lang: cn
-          path: https://docs.emqx.com/zh/emqx/v${CE_MINOR_VERSION}/admin/api-docs.html
+          path: https://docs.emqx.com/en/emqx/v${CE_MINOR_VERSION}/admin/api-docs.html
 
 - title_en: EMQX Clustering
   title_cn: 构建集群


### PR DESCRIPTION
The current Chinese API doc contains a large amount of English content, which needs to be translated into Chinese. Until the translation is complete, the Chinese API doc will be temporarily taken offline.