### PR TITLE
docs: update RocketMQ configuration instructions to clarify namespace usage

### DIFF
--- a/en_US/data-integration/data-bridge-rocketmq.md
+++ b/en_US/data-integration/data-bridge-rocketmq.md
@@ -146,7 +146,7 @@ The following steps assume that you run both EMQX and RocketMQ on the local mach
 4. In the **Configuration** step, configure the following information:
    - **Connector name**: Enter a name for the connector, which should be a combination of upper and lower-case letters and numbers, for example: `my_rocketmq`.
    - **Servers**: Enter `127.0.0.1:9876`.
-   - **Namespace**: Leave this field empty unless your RocketMQ service is configured with a namespace. For RocketMQ services hosted on Alibaba Cloud, the namespace corresponds to the instance ID.
+   - **Namespace**: Leave this field empty unless your RocketMQ service is configured with a namespace.
    - **AccessKey**, **SecretKey,** and **Secret Token**: Leave these fields empty or fill them according to your specific RocketMQ service configurations.
    - Leave others as default.
 5. Advanced settings (optional):  For details, see [Features of Sink](./data-bridges.md#features-of-sink).

--- a/ja_JP/data-integration/data-bridge-rocketmq.md
+++ b/ja_JP/data-integration/data-bridge-rocketmq.md
@@ -147,7 +147,7 @@ Linux環境では、`host.docker.internal`を実際のIPアドレスに変更し
 4. **Configuration**ステップで以下を設定します：
    - **Connector name**：コネクター名を入力します。英数字の組み合わせで、例：`my_rocketmq`
    - **Servers**：`127.0.0.1:9876`を入力
-   - **Namespace**：RocketMQサービスにネームスペースが設定されていなければ空欄のまま。Alibaba CloudホストのRocketMQの場合はインスタンスIDに対応
+   - **Namespace**：RocketMQサービスにネームスペースが設定されていなければ空欄のまま。
    - **AccessKey**、**SecretKey**、**Secret Token**：サービス構成に応じて空欄または入力
    - その他はデフォルトのまま
 5. 詳細設定（任意）：[Sinkの機能](./data-bridges.md#features-of-sink)を参照

--- a/zh_CN/data-integration/data-bridge-rocketmq.md
+++ b/zh_CN/data-integration/data-bridge-rocketmq.md
@@ -146,7 +146,7 @@ docker run --rm -e NAMESRV_ADDR=host.docker.internal:9876 apache/rocketmq:4.9.4 
 
    - **连接器名称**：应为大写和小写字母及数字的组合，例如：`my_rocketmq`。
    - **服务器列表**：输入 `127.0.0.1:9876`。
-   - **命名空间**：此处留空。如果您的 RocketMQ 服务配置了命名空间，则必须填写此项。对于阿里云的 RocketMQ 服务来说，命名空间就是实例 ID。
+   - **命名空间**：此处留空。如果您的 RocketMQ 服务配置了命名空间，则必须填写此项。
    - **Accesskey**、**Secretkey** 与**安全令牌**：此处留空，或根据您的 RocketMQ 实际配置填写。
 4. 高级配置（可选）：详细请参考 [Sink 的特性](./data-bridges.md#sink-的特性)。
 5. 在点击**创建**之前，您可以点击**测试连接**来测试连接器是否能连接到 RocketMQ 服务器。


### PR DESCRIPTION
I have tried the Alibaba Cloud RocketMQ service. There is no need to fill the Namespace field.