### PR TITLE
fix: remove broken Go/Python RTC token reference links

### DIFF
--- a/en_US/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/en_US/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -32,8 +32,6 @@ RTC tokens are generated using `AppKey` with the HMAC-SHA256 algorithm. Volcano 
 
 | Language      | Reference Implementation                                     |
 | ------------- | ------------------------------------------------------------ |
-| Go            | [AccessToken.go](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo/internal/pkg/rtctoken/token.go) |
-| Python        | [access_token.py](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo-python/src/rtctoken/access_token.py) |
 | Node.js / Bun | [token.ts](https://github.com/emqx/mcp-ai-companion-demo/tree/volcengine/rtc/volc-server/src/lib/token.ts) |
 
 ```

--- a/ja_JP/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/ja_JP/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -32,8 +32,6 @@ RTC tokens are generated using `AppKey` with the HMAC-SHA256 algorithm. Volcano 
 
 | Language      | Reference Implementation                                     |
 | ------------- | ------------------------------------------------------------ |
-| Go            | [AccessToken.go](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo/internal/pkg/rtctoken/token.go) |
-| Python        | [access_token.py](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo-python/src/rtctoken/access_token.py) |
 | Node.js / Bun | [token.ts](https://github.com/emqx/mcp-ai-companion-demo/tree/volcengine/rtc/volc-server/src/lib/token.ts) |
 
 ```

--- a/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -30,8 +30,6 @@ Token 使用 `AppKey` 通过 HMAC-SHA256 算法生成。火山引擎提供各语
 
 | 语言 | 参考实现 |
 |------|----------|
-| Go | [AccessToken.go](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo/internal/pkg/rtctoken/token.go) |
-| Python | [access_token.py](https://github.com/volcengine/rtc-aigc-demo/blob/main/server/rtc-aigc-demo-python/src/rtctoken/access_token.py) |
 | Node.js / Bun | [token.ts](https://github.com/emqx/mcp-ai-companion-demo/tree/volcengine/rtc/volc-server/src/lib/token.ts) |
 
 ```typescript


### PR DESCRIPTION
The volcengine/rtc-aigc-demo repository was restructured and the Go and Python token implementation files no longer exist (404).