### PR TITLE
docs(zh_CN): fix Volcengine RTC API docs and integration guide

### DIFF
--- a/en_US/emqx-ai/rtc-services/volcengine-rtc/api.md
+++ b/en_US/emqx-ai/rtc-services/volcengine-rtc/api.md
@@ -2,13 +2,21 @@
 
 This document describes the core APIs of Volcano Engine Real-Time Conversational AI, including `StartVoiceChat`, `UpdateVoiceChat`, `StopVoiceChat`, and related configuration parameters.
 
+## API Overview
+
+| API | Description |
+|-----|-------------|
+| [StartVoiceChat](#startvoicechat) | Start an AI voice session, creating an AI agent in the specified room |
+| [StopVoiceChat](#stopvoicechat) | Stop a voice session and release AI agent resources |
+| [UpdateVoiceChat](#updatevoicechat) | Update an ongoing voice session (interrupt, custom announcements, etc.) |
+
+All APIs require V4 signing with AccessKey. See [Authentication Proxy Service](./installation-and-testing.md#authentication-proxy-service).
+
 ## StartVoiceChat
 
-Starts a voice session and returns RTC connection credentials.
+Starts an AI voice session and creates an AI agent in the specified room.
 
-Request endpoint: `POST https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01`
-
-Request headers: Requests must be signed using AccessKey. See Authentication Proxy Service.
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
@@ -17,8 +25,8 @@ Request headers: Requests must be signed using AccessKey. See Authentication Pro
 | `AppId`       | string | Yes      | RTC application ID                                        |
 | `RoomId`      | string | Yes      | Room ID                                                   |
 | `TaskId`      | string | Yes      | Task ID used to identify the session                      |
-| `AgentConfig` | object | Yes      | Agent configuration                                       |
-| `Config`      | object | Yes      | Session configuration, including ASR, TTS, LLM parameters |
+| `AgentConfig` | object | Yes      | Agent configuration, see [AgentConfig](#agentconfig)      |
+| `Config`      | object | Yes      | Session configuration, including ASR, TTS, LLM parameters, see [Config](#config) |
 
 ### AgentConfig
 
@@ -26,43 +34,27 @@ Agent configuration:
 
 | Parameter                         | Type     | Required | Description                        |
 | --------------------------------- | -------- | -------- | ---------------------------------- |
-| `TargetUserId`                    | string[] | Yes      | Target user ID list                |
-| `UserId`                          | string   | Yes      | Agent user ID                      |
-| `WelcomeMessage`                  | string   | No       | Welcome message                    |
-| `EnableConversationStateCallback` | boolean  | No       | Enable conversation state callback |
-| `AnsMode`                         | number   | No       | Noise reduction mode (0–3)         |
-| `VoicePrint`                      | object   | No       | Voiceprint recognition settings    |
-
-VoicePrint configuration:
-
-| Parameter | Type     | Description                               |
-| --------- | -------- | ----------------------------------------- |
-| `Mode`    | number   | Voiceprint mode (0: disabled, 1: enabled) |
-| `IdList`  | string[] | Voiceprint ID list                        |
+| `TargetUserId`                    | string[] | Yes      | Target user ID list (client user IDs) |
+| `UserId`                          | string   | Yes      | Agent user ID (AI Bot identifier)  |
+| `WelcomeMessage`                  | string   | No       | Welcome message, auto-played at session start |
+| `EnableConversationStateCallback` | boolean  | No       | Enable conversation state callback for listening/thinking/speaking states |
+| `AnsMode`                         | number   | No       | AI noise reduction mode (0: off, 1: low, 2: medium, 3: high, recommended 3) |
+| `VoicePrint`                      | object   | No       | Voiceprint recognition: `Mode` (0: off, 1: on), `IdList` (voiceprint ID list) |
 
 ### Config
 
-Session configuration with the following sub-sections:
-
-```
-{
-  "ASRConfig": { ... },
-  "TTSConfig": { ... },
-  "LLMConfig": { ... },
-  "InterruptMode": 0
-}
-```
+Session configuration:
 
 | Parameter       | Type   | Description                                                 |
 | --------------- | ------ | ----------------------------------------------------------- |
-| `ASRConfig`     | object | Speech recognition configuration                            |
-| `TTSConfig`     | object | Speech synthesis configuration                              |
-| `LLMConfig`     | object | Large language model configuration                          |
+| `ASRConfig`     | object | Speech recognition configuration, see [ASRConfig](#asrconfig) |
+| `TTSConfig`     | object | Speech synthesis configuration, see [TTSConfig](#ttsconfig) |
+| `LLMConfig`     | object | Large language model configuration, see [LLMConfig](#llmconfig) |
 | `InterruptMode` | number | Interrupt mode (0: semantic interrupt, 1: manual interrupt) |
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -71,43 +63,35 @@ Session configuration with the following sub-sections:
     "Service": "rtc",
     "Region": "cn-north-1"
   },
-  "Result": {
-    "AppId": "your-app-id",
-    "RoomId": "room-uuid",
-    "UserId": "user-uuid",
-    "Token": "rtc-token..."
-  }
+  "Result": {}
 }
 ```
 
-| Field           | Description                           |
-| --------------- | ------------------------------------- |
-| `Result.AppId`  | RTC application ID                    |
-| `Result.RoomId` | RTC room ID                           |
-| `Result.UserId` | RTC user ID                           |
-| `Result.Token`  | RTC access token (valid for 24 hours) |
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
 
-Official documentation:
- [StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)
+::: tip Note
+`StartVoiceChat` is used to start an AI agent in an existing room.
+:::
+
+Official documentation: [StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)
 
 ## StopVoiceChat
 
-Stops a voice session and releases resources.
+Stops a voice session and releases AI agent resources.
 
-Request endpoint:
- `POST https://rtc.volcengineapi.com?Action=StopVoiceChat&Version=2024-12-01`
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=StopVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
 | Parameter | Type   | Required | Description        |
 | --------- | ------ | -------- | ------------------ |
-| `AppId`   | string | Yes      | RTC application ID |
-| `RoomId`  | string | Yes      | Room ID            |
-| `TaskId`  | string | Yes      | Task ID            |
+| `AppId`   | string | Yes      | RTC application ID (same as StartVoiceChat) |
+| `RoomId`  | string | Yes      | Room ID (same as StartVoiceChat) |
+| `TaskId`  | string | Yes      | Task ID (same as StartVoiceChat) |
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -118,15 +102,15 @@ Request endpoint:
 }
 ```
 
-Official documentation:
- [StopVoiceChat](https://www.volcengine.com/docs/6348/1404672)
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
+
+Official documentation: [StopVoiceChat](https://www.volcengine.com/docs/6348/1404672)
 
 ## UpdateVoiceChat
 
 Updates an ongoing voice session. Supports interruption, function calling, and custom announcements.
 
-Request endpoint:
- `POST https://rtc.volcengineapi.com?Action=UpdateVoiceChat&Version=2024-12-01`
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=UpdateVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
@@ -149,7 +133,7 @@ Request endpoint:
 
 ### InterruptMode Priority
 
-Used with `ExternalTextToSpeech`:
+Used with `ExternalTextToSpeech` to specify announcement priority:
 
 | Value | Description                                                  |
 | ----- | ------------------------------------------------------------ |
@@ -159,9 +143,9 @@ Used with `ExternalTextToSpeech`:
 
 ### Examples
 
-Interrupt the agent:
+**Interrupt the agent**:
 
-```
+```json
 {
   "AppId": "your-app-id",
   "RoomId": "room-uuid",
@@ -170,9 +154,9 @@ Interrupt the agent:
 }
 ```
 
-Custom announcement:
+**Custom announcement**:
 
-```
+```json
 {
   "AppId": "your-app-id",
   "RoomId": "room-uuid",
@@ -185,7 +169,7 @@ Custom announcement:
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -196,10 +180,15 @@ Custom announcement:
 }
 ```
 
-Official documentation:
- [UpdateVoiceChat](https://www.volcengine.com/docs/6348/1404671)
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
 
-## ASRConfig
+Official documentation: [UpdateVoiceChat](https://www.volcengine.com/docs/6348/1404671)
+
+## Configuration Details
+
+The following configurations are used in the `Config` parameter of `StartVoiceChat`.
+
+### ASRConfig
 
 Speech recognition configuration:
 
@@ -212,7 +201,7 @@ Speech recognition configuration:
 | `TurnDetectionMode` | number | No       | Turn detection mode                    |
 | `InterruptConfig`   | object | No       | Interrupt configuration                |
 
-### ProviderParams
+**ProviderParams**:
 
 | Parameter           | Type   | Description                                            |
 | ------------------- | ------ | ------------------------------------------------------ |
@@ -223,9 +212,7 @@ Speech recognition configuration:
 | `boosting_table_id` | string | Hotword table ID                                       |
 | `correct_table_id`  | string | Correction table ID                                    |
 
-### VADConfig
-
-Voice activity detection configuration:
+**VADConfig** (Voice Activity Detection):
 
 | Parameter     | Type    | Description                                    |
 | ------------- | ------- | ---------------------------------------------- |
@@ -236,18 +223,16 @@ Voice activity detection configuration:
 | `Sensitivity` | number  | Sensitivity                                    |
 | `AIVAD`       | boolean | Enable AI VAD                                  |
 
-### InterruptConfig
-
-Interrupt configuration:
+**InterruptConfig**:
 
 | Parameter                 | Type     | Description                                   |
 | ------------------------- | -------- | --------------------------------------------- |
 | `InterruptSpeechDuration` | number   | Interrupt speech duration (ms), default `400` |
 | `InterruptKeywords`       | string[] | Semantic interrupt keyword list               |
 
-Example:
+**Example configuration**:
 
-```
+```json
 {
   "Provider": "volcano",
   "ProviderParams": {
@@ -267,7 +252,7 @@ Example:
 }
 ```
 
-## TTSConfig
+### TTSConfig
 
 Speech synthesis configuration:
 
@@ -277,7 +262,7 @@ Speech synthesis configuration:
 | `ProviderParams`    | object   | Yes      | Provider-specific parameters         |
 | `IgnoreBracketText` | number[] | No       | Bracket types to ignore              |
 
-### ProviderParams
+**ProviderParams**:
 
 | Parameter    | Type   | Description        |
 | ------------ | ------ | ------------------ |
@@ -286,7 +271,7 @@ Speech synthesis configuration:
 | `ResourceId` | string | TTS resource ID    |
 | `Additions`  | object | Additional config  |
 
-App configuration:
+**app configuration**:
 
 | Parameter | Type   | Description                            |
 | --------- | ------ | -------------------------------------- |
@@ -294,18 +279,29 @@ App configuration:
 | `token`   | string | TTS application token                  |
 | `cluster` | string | Service cluster, default `volcano_tts` |
 
-Audio configuration:
+**audio configuration**:
 
-| Parameter          | Type   | Description      | Range                              |
-| ------------------ | ------ | ---------------- | ---------------------------------- |
-| `voice_type`       | string | Voice type       | See voice list                     |
-| `speed_ratio`      | number | Speech rate      | 0.5–2.0, default `1.0`             |
-| `pitch_ratio`      | number | Pitch            | 0.5–2.0, default `1.0`             |
-| `volume_ratio`     | number | Volume           | 0.5–2.0, default `1.0`             |
-| `emotion`          | string | Emotion          | `happy`, `sad`, `angry`, `neutral` |
-| `emotion_strength` | number | Emotion strength | 0.0–1.0, default `0.8`             |
+Parameters vary slightly by TTS mode:
 
-Common voices:
+| Parameter          | Type   | Description      | Applicable Mode |
+| ------------------ | ------ | ---------------- | --------------- |
+| `voice_type`       | string | Voice type       | All modes       |
+| `volume_ratio`     | number | Volume (0.5–2.0) | All modes       |
+| `speed_ratio`      | number | Speech rate (0.5–2.0) | standard   |
+| `pitch_ratio`      | number | Pitch (0.5–2.0)  | standard        |
+| `speech_ratio`     | number | Speech rate (0.5–2.0) | bigtts     |
+| `pitch_rate`       | number | Pitch rate       | bigtts          |
+| `speech_rate`      | number | Speech rate      | bidirection     |
+| `emotion`          | string | Emotion: `happy`, `sad`, `angry`, `neutral` | Voices with emotion support |
+| `emotion_strength` | number | Emotion strength (0.0–1.0) | With emotion |
+
+::: tip TTS Modes
+- `standard`: Standard mode, uses `speed_ratio`, `pitch_ratio`
+- `bigtts`: Large model TTS, uses `speech_ratio`, `pitch_rate`
+- `bidirection`: Bidirectional streaming, uses `speech_rate`, supports `Additions` config
+:::
+
+**Common voices**:
 
 | Voice ID          | Description    |
 | ----------------- | -------------- |
@@ -314,12 +310,11 @@ Common voices:
 | `BV700_streaming` | Female, sweet  |
 | `BV406_streaming` | Male, calm     |
 
-More voices:
- [Volcano Engine TTS Voice List](https://www.volcengine.com/docs/6561)
+More voices: [Volcano Engine TTS Voice List](https://www.volcengine.com/docs/6561)
 
-Example:
+**Example configuration**:
 
-```
+```json
 {
   "Provider": "volcano",
   "ProviderParams": {
@@ -341,13 +336,13 @@ Example:
 }
 ```
 
-## LLMConfig
+### LLMConfig
 
 Large language model configuration:
 
 | Parameter        | Type     | Required       | Description                                     |
 | ---------------- | -------- | -------------- | ----------------------------------------------- |
-| `Mode`           | string   | Yes            | `ArkV3` or `CustomLLM`                          |
+| `Mode`           | string   | Yes            | Mode: `ArkV3` (Ark) or `CustomLLM` (custom)     |
 | `Url`            | string   | CustomLLM only | CustomLLM callback URL                          |
 | `APIKey`         | string   | No             | API authentication key                          |
 | `EndPointId`     | string   | ArkV3 only     | Ark model endpoint ID                           |
@@ -359,30 +354,21 @@ Large language model configuration:
 | `MaxTokens`      | number   | No             | Max tokens, default `256`                       |
 | `HistoryLength`  | number   | No             | Number of history turns to keep, default `15`   |
 | `EnableRoundId`  | boolean  | No             | Enable round ID                                 |
-| `VisionConfig`   | object   | No             | Vision understanding config                     |
-| `Custom`         | string   | No             | Custom parameters (JSON string), passed through |
+| `VisionConfig`   | object   | No             | Vision understanding: `Enable` (boolean), `SnapshotConfig` (object) |
+| `Custom`         | string   | No             | Custom parameters (JSON string), passed through to CustomLLM |
 
-### VisionConfig
+**UserPrompts** (Preset conversation history):
 
-| Parameter        | Type    | Description                 |
-| ---------------- | ------- | --------------------------- |
-| `Enable`         | boolean | Enable vision understanding |
-| `SnapshotConfig` | object  | Snapshot configuration      |
-
-### UserPrompts
-
-Preset conversation history:
-
-```
+```json
 [
   { "Role": "assistant", "Content": "Hello! How can I help you?" },
   { "Role": "user", "Content": "Hello" }
 ]
 ```
 
-CustomLLM example:
+**CustomLLM mode example**:
 
-```
+```json
 {
   "Mode": "CustomLLM",
   "Url": "https://your-server.com/chat-stream",
@@ -397,14 +383,14 @@ CustomLLM example:
     "Enable": false
   },
   "UserPrompts": [
-    { "Role": "assistant", "Content": "Hi, I’m your assistant. Nice to meet you!" }
+    { "Role": "assistant", "Content": "Hi, I'm your assistant. Nice to meet you!" }
   ]
 }
 ```
 
-ArkV3 example:
+**ArkV3 mode example**:
 
-```
+```json
 {
   "Mode": "ArkV3",
   "EndPointId": "your-endpoint-id",
@@ -415,7 +401,7 @@ ArkV3 example:
 
 ## CustomLLM Callback
 
-When using CustomLLM mode, Volcano Engine sends ASR results to the custom service.
+When using CustomLLM mode, Volcano Engine sends user speech recognition results to your custom service.
 
 ### Callback Flow
 
@@ -425,7 +411,9 @@ User speech → Volcano Engine ASR → CustomLLM service → Volcano Engine TTS 
 
 ### Request Format
 
-```
+Request from Volcano Engine to your CustomLLM service:
+
+```http
 POST /chat-stream HTTP/1.1
 Authorization: Bearer YOUR_API_KEY
 Content-Type: application/json
@@ -442,12 +430,38 @@ Content-Type: application/json
 }
 ```
 
+**Request fields**:
+
+| Field         | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `messages`    | Conversation history in OpenAI format          |
+| `stream`      | Fixed `true`, requires streaming response      |
+| `temperature` | Sampling temperature                           |
+| `max_tokens`  | Maximum generation length                      |
+| `device_id`   | Custom parameter, passed through from `LLMConfig.Custom` |
+
 ### Response Format
 
-The response must follow the OpenAI SSE format and end with `data: [DONE]`.
+Response must follow OpenAI SSE format:
 
-Official documentation:
- [CustomLLM Integration](https://www.volcengine.com/docs/6348/1399966)
+```
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"model":"qwen-flash","created":1704355200}
+
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}],"model":"qwen-flash","created":1704355200}
+
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"model":"qwen-flash","created":1704355200}
+
+data: [DONE]
+```
+
+**Response requirements**:
+
+- Must return SSE streaming response
+- Content-Type: `text/event-stream`
+- Each line starts with `data: `
+- Last line must be `data: [DONE]`
+
+Official documentation: [CustomLLM Integration](https://www.volcengine.com/docs/6348/1399966)
 
 ## RTC Token
 
@@ -459,10 +473,10 @@ Clients need a token to join an RTC room. Tokens are generated server-side using
 Token = Version + AppId + Base64(Message + Signature)
 ```
 
-- Version: fixed value `001`
-- AppId: 24-character application identifier
-- Message: binary-encoded payload (RoomId, UserId, expiry time, privileges)
-- Signature: HMAC-SHA256 signature using AppKey
+- **Version**: fixed value `001`
+- **AppId**: 24-character application identifier
+- **Message**: binary-encoded payload (RoomId, UserId, expiry time, privileges)
+- **Signature**: HMAC-SHA256 signature using AppKey
 
 ### Token Privileges
 
@@ -473,11 +487,11 @@ Token = Version + AppId + Base64(Message + Signature)
 
 ### Validity
 
-Default validity is 24 hours (86,400 seconds).
+Default validity is 24 hours (86,400 seconds). Must be regenerated after expiry.
 
 ### Example
 
-```
+```typescript
 import { AccessToken } from './rtctoken'
 
 const token = new AccessToken(appId, appKey, roomId, userId)
@@ -488,11 +502,13 @@ token.expireTime(expireAt)
 const tokenString = token.serialize()
 ```
 
+For token generation libraries, see [Installation and Testing - Generating an RTC Token](./installation-and-testing.md#generating-an-rtc-token).
+
 ## Error Codes
 
 ### Response Format
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "xxx",
@@ -535,11 +551,10 @@ const tokenString = token.serialize()
 | `TaskNotExist` | Task does not exist             |
 | `InvalidToken` | RTC token is invalid or expired |
 
-Official documentation:
- [Common Error Codes](https://www.volcengine.com/docs/6369/68677)
+Official documentation: [Common Error Codes](https://www.volcengine.com/docs/6369/68677)
 
 ## Related Resources
 
 - [Installation and Testing](./installation-and-testing.md)
-- [Volcano Engine Real-Time Conversational API Documentation](https://www.volcengine.com/docs/6348/1315560)
+- [Volcano Engine Real-Time Conversational API Documentation](https://www.volcengine.com/docs/6348/1315560) - Official complete documentation
 - [Volcano Engine Real-Time Audio and Video Documentation](https://www.volcengine.com/docs/6348)

--- a/en_US/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/en_US/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -4,8 +4,7 @@ This document explains how to integrate Volcano Engine speech services and compl
 
 ## Prerequisites
 
-Before starting integration, make sure you have enabled the required Volcano Engine services and configured credentials. For detailed steps, see
- Quick Start – Volcano Engine Credentials.
+Before starting integration, make sure you have enabled the required Volcano Engine services and configured credentials. For detailed steps, see [Quick Start – Volcano Engine Credentials](./quick-start.md#4-volcano-engine-credentials).
 
 Required credentials:
 
@@ -24,29 +23,29 @@ The proxy service is responsible for:
 
 - Generating RTC tokens using `AppKey`
 - Calling Volcano Engine OpenAPI using `AccessKey`
-- Returning tokens and room information to the client
+- Returning `Token` and room information to the client
 
 ### Generating an RTC Token
 
-RTC tokens are generated using `AppKey` with the HMAC-SHA256 algorithm. Volcano Engine provides reference implementations in multiple languages:
+`Token` is generated using `AppKey` with the HMAC-SHA256 algorithm:
 
 | Language      | Reference Implementation                                     |
 | ------------- | ------------------------------------------------------------ |
 | Node.js / Bun | [token.ts](https://github.com/emqx/mcp-ai-companion-demo/tree/volcengine/rtc/volc-server/src/lib/token.ts) |
 
-```
+```typescript
 import { AccessToken, Privileges } from './rtctoken'
 
 const token = new AccessToken(appId, appKey, roomId, userId)
 token.addPrivilege(Privileges.PrivPublishStream, expireTime)
-const tokenString = token.serialize() // Return to the client
+const tokenString = token.serialize()  // Return to the client
 ```
 
 ### Calling Volcano Engine OpenAPI
 
-APIs such as `StartVoiceChat` and `StopVoiceChat` must be signed using `AccessKeyId` and `SecretKey`. The official OpenAPI SDK handles signing automatically:
+APIs such as `StartVoiceChat` and `StopVoiceChat` require V4 signing using `AccessKeyId` and `SecretKey`. The official OpenAPI SDK provides a `Signer` class to generate the required headers:
 
-```
+```bash
 # Node.js / Bun
 npm install @volcengine/openapi
 
@@ -55,45 +54,79 @@ pip install volcengine-python-sdk
 
 # Go
 go get github.com/volcengine/volc-sdk-golang
+```
+
+```typescript
 // Node.js example
 import { Signer } from '@volcengine/openapi'
 
-const signer = new Signer(
-  {
-    accessKeyId: process.env.ACCESS_KEY_ID,
-    secretKey: process.env.SECRET_KEY,
-  },
-  'rtc'
-)
+const body = { AppId: appId, RoomId: roomId, /* ... */ }
 
-const response = await signer.fetch('https://rtc.volcengineapi.com', {
+// Build the request data
+const openApiRequestData = {
+  region: 'cn-north-1',
   method: 'POST',
-  query: { Action: 'StartVoiceChat', Version: '2024-12-01' },
-  body: { AppId: appId, RoomId: roomId, ... },
+  params: {
+    Action: 'StartVoiceChat',
+    Version: '2024-12-01',
+  },
+  headers: {
+    Host: 'rtc.volcengineapi.com',
+    'Content-Type': 'application/json',
+  },
+  body,
+}
+
+// Create Signer and add authorization headers
+const signer = new Signer(openApiRequestData, 'rtc')
+signer.addAuthorization({
+  accessKeyId: process.env.ACCESS_KEY_ID,
+  secretKey: process.env.SECRET_KEY,
 })
-// response includes Token, RoomId, UserId, etc., which are returned to the client
+
+// Send the request (headers now include the signature)
+const response = await fetch(
+  'https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01',
+  {
+    method: 'POST',
+    headers: openApiRequestData.headers,
+    body: JSON.stringify(body),
+  }
+)
 ```
 
-For detailed signing rules, see
- [Volcano Engine V4 Signature Algorithm](https://www.volcengine.com/docs/6369/67269).
+For detailed signing rules, see [Volcano Engine V4 Signature Algorithm](https://www.volcengine.com/docs/6369/67269).
 
 ### Example API Design
 
 The proxy service should expose APIs for client use:
 
-```
-// Start a voice session – returns token and room info
+```typescript
+// Get scene configuration – returns Token and room info
+GET /api/scenes
+Response: {
+  scenes: [{
+    id: string,
+    rtcConfig: { appId: string, roomId: string, userId: string, token: string }
+  }]
+}
+
+// Start a voice session
 POST /api/voice/start
 Request:  { sceneId: string }
-Response: { roomId: string, token: string, userId: string, appId: string }
+Response: { success: boolean }
 
 // Stop a voice session
 POST /api/voice/stop
-Request:  { roomId: string }
+Request:  { sceneId: string }
 Response: { success: boolean }
 ```
 
-Internally, these endpoints call the Volcano Engine OpenAPI (`StartVoiceChat`, `StopVoiceChat`) and pass the returned token and related information back to the client.
+Server-side implementation notes:
+
+- **Scene configuration**: The server generates a `roomId` (UUID) and `userId` for each scene at initialization, and uses `AppKey` to generate the corresponding RTC Token (valid for 24 hours). Clients retrieve this information via `/api/scenes` to join the RTC room.
+- **Token usage**: Clients pass the Token to the RTC SDK's `joinRoom` method for authentication.
+- **Starting/stopping voice sessions**: The server looks up the scene configuration by `sceneId`, retrieves `roomId` and other parameters, then calls the Volcano Engine OpenAPI (`StartVoiceChat`, `StopVoiceChat`).
 
 ## Web Integration
 
@@ -103,7 +136,7 @@ Volcano Engine provides the `@volcengine/rtc` SDK for Web integration. The inter
 
 ### Install the SDK
 
-```
+```bash
 npm install @volcengine/rtc
 ```
 
@@ -111,40 +144,45 @@ For AI noise reduction, the SDK includes the `@volcengine/rtc/extension-ainr` ex
 
 ### Basic Integration Flow
 
-#### 1. Call the Server API to Get a Token
+#### 1. Get Scene Configuration
 
-Before using the RTC SDK, call the server API to start a voice session and retrieve the token and room information:
+Before using the RTC SDK, call the server API to get the scene configuration, including the Token and room information:
 
-```
-const response = await fetch('/api/voice/start', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ sceneId: 'your-scene-id' }),
-})
+```typescript
+// Call the server API to get scene configuration
+const response = await fetch('/api/scenes')
+const { scenes } = await response.json()
 
-const { appId, roomId, token, userId } = await response.json()
+// Select the target scene
+const scene = scenes.find(s => s.id === 'your-scene-id') || scenes[0]
+const { appId, roomId, token, userId } = scene.rtcConfig
 ```
 
 #### 2. Create the RTC Engine
 
-```
+```typescript
 import VERTC, { RoomProfileType, MediaType } from '@volcengine/rtc'
 
+// Create engine instance using the appId from the server
 const engine = VERTC.createEngine(appId)
 ```
 
 #### 3. Register Event Listeners
 
-```
+```typescript
+// Listen for errors
 engine.on(VERTC.events.onError, (event) => {
   console.error('RTC error:', event.errorCode)
 })
 
+// Listen for remote user publishing stream (AI voice response)
 engine.on(VERTC.events.onUserPublishStream, async (event) => {
   const { userId, mediaType } = event
+  // Subscribe to remote audio stream
   await engine.subscribeStream(userId, mediaType)
 })
 
+// Listen for binary messages (subtitles, status, etc.)
 engine.on(VERTC.events.onRoomBinaryMessageReceived, (event) => {
   const { message } = event
   // message is an ArrayBuffer in TLV format
@@ -154,12 +192,13 @@ engine.on(VERTC.events.onRoomBinaryMessageReceived, (event) => {
 
 #### 4. Join the Room
 
-```
+```typescript
+// Use token, roomId, userId from step 1 to join the room
 await engine.joinRoom(
   token,
   roomId,
   {
-    userId,
+    userId: userId,
     extraInfo: JSON.stringify({
       call_scene: 'RTC-AIGC',
       user_name: userId,
@@ -175,41 +214,69 @@ await engine.joinRoom(
 
 #### 5. Start the Microphone and Publish Audio
 
-```
+```typescript
+// Start microphone capture
 await engine.startAudioCapture()
+
+// Publish audio stream to the room
 await engine.publishStream(MediaType.AUDIO)
+```
+
+#### 6. Start Voice Session
+
+After publishing the audio stream, call the server API to start the AI voice session:
+
+```typescript
+// Start voice session
+await fetch('/api/voice/start', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ sceneId: scene.id }),
+})
 ```
 
 At this point, voice interaction begins. User speech is recognized by ASR, processed by the LLM, and played back via TTS.
 
-#### 6. Leave the Room
+#### 7. Leave the Room
 
-```
+```typescript
+// Stop publishing
 await engine.unpublishStream(MediaType.AUDIO)
+
+// Stop capture
 await engine.stopAudioCapture()
+
+// Leave the room
 await engine.leaveRoom()
+
+// Destroy the engine
 VERTC.destroyEngine(engine)
 
+// Call server API to stop the voice session
 await fetch('/api/voice/stop', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ roomId }),
+  body: JSON.stringify({ sceneId: scene.id }),
 })
 ```
 
 ### AI Noise Reduction (Optional)
 
-The RTC SDK includes built-in AI noise reduction:
+The Volcano Engine RTC SDK includes built-in AI noise reduction extension to effectively filter environmental noise:
 
-```
+```typescript
 import RTCAIAnsExtension, { AnsMode } from '@volcengine/rtc/extension-ainr'
 
+// Create and register extension
 const aiAnsExtension = new RTCAIAnsExtension()
 engine.registerExtension(aiAnsExtension)
 
+// Check if supported
 const supported = await aiAnsExtension.isSupported()
 if (supported) {
+  // Set noise reduction mode: LOW / MEDIUM / HIGH
   await aiAnsExtension.setAnsMode(AnsMode.MEDIUM)
+  // Enable noise reduction
   aiAnsExtension.enable()
 }
 ```
@@ -218,20 +285,19 @@ if (supported) {
 
 After subscribing to a remote stream, you can obtain a `MediaStream` for playback:
 
-```
+```typescript
 import { StreamIndex } from '@volcengine/rtc'
 
-const audioTrack = engine.getRemoteStreamTrack(
-  userId,
-  StreamIndex.STREAM_INDEX_MAIN,
-  'audio'
-)
+// Get remote user's audio track
+const audioTrack = engine.getRemoteStreamTrack(userId, StreamIndex.STREAM_INDEX_MAIN, 'audio')
 
+// Create MediaStream and play
 const stream = new MediaStream()
 if (audioTrack) {
   stream.addTrack(audioTrack)
 }
 
+// Bind to audio element for playback
 const audioElement = document.querySelector('audio')
 audioElement.srcObject = stream
 ```
@@ -265,7 +331,9 @@ Embedded Linux, RTOS, Android, and other hardware platforms are supported. Hardw
 
 ### Verify RTC Connection
 
-```
+After successfully joining a room, you can confirm via events:
+
+```typescript
 engine.on(VERTC.events.onUserJoined, (event) => {
   console.log('User joined:', event.userInfo.userId)
 })

--- a/ja_JP/emqx-ai/rtc-services/volcengine-rtc/api.md
+++ b/ja_JP/emqx-ai/rtc-services/volcengine-rtc/api.md
@@ -2,13 +2,21 @@
 
 This document describes the core APIs of Volcano Engine Real-Time Conversational AI, including `StartVoiceChat`, `UpdateVoiceChat`, `StopVoiceChat`, and related configuration parameters.
 
+## API Overview
+
+| API | Description |
+|-----|-------------|
+| [StartVoiceChat](#startvoicechat) | Start an AI voice session, creating an AI agent in the specified room |
+| [StopVoiceChat](#stopvoicechat) | Stop a voice session and release AI agent resources |
+| [UpdateVoiceChat](#updatevoicechat) | Update an ongoing voice session (interrupt, custom announcements, etc.) |
+
+All APIs require V4 signing with AccessKey. See [Authentication Proxy Service](./installation-and-testing.md#authentication-proxy-service).
+
 ## StartVoiceChat
 
-Starts a voice session and returns RTC connection credentials.
+Starts an AI voice session and creates an AI agent in the specified room.
 
-Request endpoint: `POST https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01`
-
-Request headers: Requests must be signed using AccessKey. See Authentication Proxy Service.
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
@@ -17,8 +25,8 @@ Request headers: Requests must be signed using AccessKey. See Authentication Pro
 | `AppId`       | string | Yes      | RTC application ID                                        |
 | `RoomId`      | string | Yes      | Room ID                                                   |
 | `TaskId`      | string | Yes      | Task ID used to identify the session                      |
-| `AgentConfig` | object | Yes      | Agent configuration                                       |
-| `Config`      | object | Yes      | Session configuration, including ASR, TTS, LLM parameters |
+| `AgentConfig` | object | Yes      | Agent configuration, see [AgentConfig](#agentconfig)      |
+| `Config`      | object | Yes      | Session configuration, including ASR, TTS, LLM parameters, see [Config](#config) |
 
 ### AgentConfig
 
@@ -26,43 +34,27 @@ Agent configuration:
 
 | Parameter                         | Type     | Required | Description                        |
 | --------------------------------- | -------- | -------- | ---------------------------------- |
-| `TargetUserId`                    | string[] | Yes      | Target user ID list                |
-| `UserId`                          | string   | Yes      | Agent user ID                      |
-| `WelcomeMessage`                  | string   | No       | Welcome message                    |
-| `EnableConversationStateCallback` | boolean  | No       | Enable conversation state callback |
-| `AnsMode`                         | number   | No       | Noise reduction mode (0–3)         |
-| `VoicePrint`                      | object   | No       | Voiceprint recognition settings    |
-
-VoicePrint configuration:
-
-| Parameter | Type     | Description                               |
-| --------- | -------- | ----------------------------------------- |
-| `Mode`    | number   | Voiceprint mode (0: disabled, 1: enabled) |
-| `IdList`  | string[] | Voiceprint ID list                        |
+| `TargetUserId`                    | string[] | Yes      | Target user ID list (client user IDs) |
+| `UserId`                          | string   | Yes      | Agent user ID (AI Bot identifier)  |
+| `WelcomeMessage`                  | string   | No       | Welcome message, auto-played at session start |
+| `EnableConversationStateCallback` | boolean  | No       | Enable conversation state callback for listening/thinking/speaking states |
+| `AnsMode`                         | number   | No       | AI noise reduction mode (0: off, 1: low, 2: medium, 3: high, recommended 3) |
+| `VoicePrint`                      | object   | No       | Voiceprint recognition: `Mode` (0: off, 1: on), `IdList` (voiceprint ID list) |
 
 ### Config
 
-Session configuration with the following sub-sections:
-
-```
-{
-  "ASRConfig": { ... },
-  "TTSConfig": { ... },
-  "LLMConfig": { ... },
-  "InterruptMode": 0
-}
-```
+Session configuration:
 
 | Parameter       | Type   | Description                                                 |
 | --------------- | ------ | ----------------------------------------------------------- |
-| `ASRConfig`     | object | Speech recognition configuration                            |
-| `TTSConfig`     | object | Speech synthesis configuration                              |
-| `LLMConfig`     | object | Large language model configuration                          |
+| `ASRConfig`     | object | Speech recognition configuration, see [ASRConfig](#asrconfig) |
+| `TTSConfig`     | object | Speech synthesis configuration, see [TTSConfig](#ttsconfig) |
+| `LLMConfig`     | object | Large language model configuration, see [LLMConfig](#llmconfig) |
 | `InterruptMode` | number | Interrupt mode (0: semantic interrupt, 1: manual interrupt) |
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -71,43 +63,35 @@ Session configuration with the following sub-sections:
     "Service": "rtc",
     "Region": "cn-north-1"
   },
-  "Result": {
-    "AppId": "your-app-id",
-    "RoomId": "room-uuid",
-    "UserId": "user-uuid",
-    "Token": "rtc-token..."
-  }
+  "Result": {}
 }
 ```
 
-| Field           | Description                           |
-| --------------- | ------------------------------------- |
-| `Result.AppId`  | RTC application ID                    |
-| `Result.RoomId` | RTC room ID                           |
-| `Result.UserId` | RTC user ID                           |
-| `Result.Token`  | RTC access token (valid for 24 hours) |
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
 
-Official documentation:
- [StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)
+::: tip Note
+`StartVoiceChat` is used to start an AI agent in an existing room.
+:::
+
+Official documentation: [StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)
 
 ## StopVoiceChat
 
-Stops a voice session and releases resources.
+Stops a voice session and releases AI agent resources.
 
-Request endpoint:
- `POST https://rtc.volcengineapi.com?Action=StopVoiceChat&Version=2024-12-01`
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=StopVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
 | Parameter | Type   | Required | Description        |
 | --------- | ------ | -------- | ------------------ |
-| `AppId`   | string | Yes      | RTC application ID |
-| `RoomId`  | string | Yes      | Room ID            |
-| `TaskId`  | string | Yes      | Task ID            |
+| `AppId`   | string | Yes      | RTC application ID (same as StartVoiceChat) |
+| `RoomId`  | string | Yes      | Room ID (same as StartVoiceChat) |
+| `TaskId`  | string | Yes      | Task ID (same as StartVoiceChat) |
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -118,15 +102,15 @@ Request endpoint:
 }
 ```
 
-Official documentation:
- [StopVoiceChat](https://www.volcengine.com/docs/6348/1404672)
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
+
+Official documentation: [StopVoiceChat](https://www.volcengine.com/docs/6348/1404672)
 
 ## UpdateVoiceChat
 
 Updates an ongoing voice session. Supports interruption, function calling, and custom announcements.
 
-Request endpoint:
- `POST https://rtc.volcengineapi.com?Action=UpdateVoiceChat&Version=2024-12-01`
+**Request endpoint**: `POST https://rtc.volcengineapi.com?Action=UpdateVoiceChat&Version=2024-12-01`
 
 ### Request Parameters
 
@@ -149,7 +133,7 @@ Request endpoint:
 
 ### InterruptMode Priority
 
-Used with `ExternalTextToSpeech`:
+Used with `ExternalTextToSpeech` to specify announcement priority:
 
 | Value | Description                                                  |
 | ----- | ------------------------------------------------------------ |
@@ -159,9 +143,9 @@ Used with `ExternalTextToSpeech`:
 
 ### Examples
 
-Interrupt the agent:
+**Interrupt the agent**:
 
-```
+```json
 {
   "AppId": "your-app-id",
   "RoomId": "room-uuid",
@@ -170,9 +154,9 @@ Interrupt the agent:
 }
 ```
 
-Custom announcement:
+**Custom announcement**:
 
-```
+```json
 {
   "AppId": "your-app-id",
   "RoomId": "room-uuid",
@@ -185,7 +169,7 @@ Custom announcement:
 
 ### Response
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "20250104123456789abcdef01234567",
@@ -196,10 +180,15 @@ Custom announcement:
 }
 ```
 
-Official documentation:
- [UpdateVoiceChat](https://www.volcengine.com/docs/6348/1404671)
+On success, `Result` is an empty object. On failure, `ResponseMetadata.Error` contains the error information.
 
-## ASRConfig
+Official documentation: [UpdateVoiceChat](https://www.volcengine.com/docs/6348/1404671)
+
+## Configuration Details
+
+The following configurations are used in the `Config` parameter of `StartVoiceChat`.
+
+### ASRConfig
 
 Speech recognition configuration:
 
@@ -212,7 +201,7 @@ Speech recognition configuration:
 | `TurnDetectionMode` | number | No       | Turn detection mode                    |
 | `InterruptConfig`   | object | No       | Interrupt configuration                |
 
-### ProviderParams
+**ProviderParams**:
 
 | Parameter           | Type   | Description                                            |
 | ------------------- | ------ | ------------------------------------------------------ |
@@ -223,9 +212,7 @@ Speech recognition configuration:
 | `boosting_table_id` | string | Hotword table ID                                       |
 | `correct_table_id`  | string | Correction table ID                                    |
 
-### VADConfig
-
-Voice activity detection configuration:
+**VADConfig** (Voice Activity Detection):
 
 | Parameter     | Type    | Description                                    |
 | ------------- | ------- | ---------------------------------------------- |
@@ -236,18 +223,16 @@ Voice activity detection configuration:
 | `Sensitivity` | number  | Sensitivity                                    |
 | `AIVAD`       | boolean | Enable AI VAD                                  |
 
-### InterruptConfig
-
-Interrupt configuration:
+**InterruptConfig**:
 
 | Parameter                 | Type     | Description                                   |
 | ------------------------- | -------- | --------------------------------------------- |
 | `InterruptSpeechDuration` | number   | Interrupt speech duration (ms), default `400` |
 | `InterruptKeywords`       | string[] | Semantic interrupt keyword list               |
 
-Example:
+**Example configuration**:
 
-```
+```json
 {
   "Provider": "volcano",
   "ProviderParams": {
@@ -267,7 +252,7 @@ Example:
 }
 ```
 
-## TTSConfig
+### TTSConfig
 
 Speech synthesis configuration:
 
@@ -277,7 +262,7 @@ Speech synthesis configuration:
 | `ProviderParams`    | object   | Yes      | Provider-specific parameters         |
 | `IgnoreBracketText` | number[] | No       | Bracket types to ignore              |
 
-### ProviderParams
+**ProviderParams**:
 
 | Parameter    | Type   | Description        |
 | ------------ | ------ | ------------------ |
@@ -286,7 +271,7 @@ Speech synthesis configuration:
 | `ResourceId` | string | TTS resource ID    |
 | `Additions`  | object | Additional config  |
 
-App configuration:
+**app configuration**:
 
 | Parameter | Type   | Description                            |
 | --------- | ------ | -------------------------------------- |
@@ -294,18 +279,29 @@ App configuration:
 | `token`   | string | TTS application token                  |
 | `cluster` | string | Service cluster, default `volcano_tts` |
 
-Audio configuration:
+**audio configuration**:
 
-| Parameter          | Type   | Description      | Range                              |
-| ------------------ | ------ | ---------------- | ---------------------------------- |
-| `voice_type`       | string | Voice type       | See voice list                     |
-| `speed_ratio`      | number | Speech rate      | 0.5–2.0, default `1.0`             |
-| `pitch_ratio`      | number | Pitch            | 0.5–2.0, default `1.0`             |
-| `volume_ratio`     | number | Volume           | 0.5–2.0, default `1.0`             |
-| `emotion`          | string | Emotion          | `happy`, `sad`, `angry`, `neutral` |
-| `emotion_strength` | number | Emotion strength | 0.0–1.0, default `0.8`             |
+Parameters vary slightly by TTS mode:
 
-Common voices:
+| Parameter          | Type   | Description      | Applicable Mode |
+| ------------------ | ------ | ---------------- | --------------- |
+| `voice_type`       | string | Voice type       | All modes       |
+| `volume_ratio`     | number | Volume (0.5–2.0) | All modes       |
+| `speed_ratio`      | number | Speech rate (0.5–2.0) | standard   |
+| `pitch_ratio`      | number | Pitch (0.5–2.0)  | standard        |
+| `speech_ratio`     | number | Speech rate (0.5–2.0) | bigtts     |
+| `pitch_rate`       | number | Pitch rate       | bigtts          |
+| `speech_rate`      | number | Speech rate      | bidirection     |
+| `emotion`          | string | Emotion: `happy`, `sad`, `angry`, `neutral` | Voices with emotion support |
+| `emotion_strength` | number | Emotion strength (0.0–1.0) | With emotion |
+
+::: tip TTS Modes
+- `standard`: Standard mode, uses `speed_ratio`, `pitch_ratio`
+- `bigtts`: Large model TTS, uses `speech_ratio`, `pitch_rate`
+- `bidirection`: Bidirectional streaming, uses `speech_rate`, supports `Additions` config
+:::
+
+**Common voices**:
 
 | Voice ID          | Description    |
 | ----------------- | -------------- |
@@ -314,12 +310,11 @@ Common voices:
 | `BV700_streaming` | Female, sweet  |
 | `BV406_streaming` | Male, calm     |
 
-More voices:
- [Volcano Engine TTS Voice List](https://www.volcengine.com/docs/6561)
+More voices: [Volcano Engine TTS Voice List](https://www.volcengine.com/docs/6561)
 
-Example:
+**Example configuration**:
 
-```
+```json
 {
   "Provider": "volcano",
   "ProviderParams": {
@@ -341,13 +336,13 @@ Example:
 }
 ```
 
-## LLMConfig
+### LLMConfig
 
 Large language model configuration:
 
 | Parameter        | Type     | Required       | Description                                     |
 | ---------------- | -------- | -------------- | ----------------------------------------------- |
-| `Mode`           | string   | Yes            | `ArkV3` or `CustomLLM`                          |
+| `Mode`           | string   | Yes            | Mode: `ArkV3` (Ark) or `CustomLLM` (custom)     |
 | `Url`            | string   | CustomLLM only | CustomLLM callback URL                          |
 | `APIKey`         | string   | No             | API authentication key                          |
 | `EndPointId`     | string   | ArkV3 only     | Ark model endpoint ID                           |
@@ -359,30 +354,21 @@ Large language model configuration:
 | `MaxTokens`      | number   | No             | Max tokens, default `256`                       |
 | `HistoryLength`  | number   | No             | Number of history turns to keep, default `15`   |
 | `EnableRoundId`  | boolean  | No             | Enable round ID                                 |
-| `VisionConfig`   | object   | No             | Vision understanding config                     |
-| `Custom`         | string   | No             | Custom parameters (JSON string), passed through |
+| `VisionConfig`   | object   | No             | Vision understanding: `Enable` (boolean), `SnapshotConfig` (object) |
+| `Custom`         | string   | No             | Custom parameters (JSON string), passed through to CustomLLM |
 
-### VisionConfig
+**UserPrompts** (Preset conversation history):
 
-| Parameter        | Type    | Description                 |
-| ---------------- | ------- | --------------------------- |
-| `Enable`         | boolean | Enable vision understanding |
-| `SnapshotConfig` | object  | Snapshot configuration      |
-
-### UserPrompts
-
-Preset conversation history:
-
-```
+```json
 [
   { "Role": "assistant", "Content": "Hello! How can I help you?" },
   { "Role": "user", "Content": "Hello" }
 ]
 ```
 
-CustomLLM example:
+**CustomLLM mode example**:
 
-```
+```json
 {
   "Mode": "CustomLLM",
   "Url": "https://your-server.com/chat-stream",
@@ -397,14 +383,14 @@ CustomLLM example:
     "Enable": false
   },
   "UserPrompts": [
-    { "Role": "assistant", "Content": "Hi, I’m your assistant. Nice to meet you!" }
+    { "Role": "assistant", "Content": "Hi, I'm your assistant. Nice to meet you!" }
   ]
 }
 ```
 
-ArkV3 example:
+**ArkV3 mode example**:
 
-```
+```json
 {
   "Mode": "ArkV3",
   "EndPointId": "your-endpoint-id",
@@ -415,7 +401,7 @@ ArkV3 example:
 
 ## CustomLLM Callback
 
-When using CustomLLM mode, Volcano Engine sends ASR results to the custom service.
+When using CustomLLM mode, Volcano Engine sends user speech recognition results to your custom service.
 
 ### Callback Flow
 
@@ -425,7 +411,9 @@ User speech → Volcano Engine ASR → CustomLLM service → Volcano Engine TTS 
 
 ### Request Format
 
-```
+Request from Volcano Engine to your CustomLLM service:
+
+```http
 POST /chat-stream HTTP/1.1
 Authorization: Bearer YOUR_API_KEY
 Content-Type: application/json
@@ -442,12 +430,38 @@ Content-Type: application/json
 }
 ```
 
+**Request fields**:
+
+| Field         | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `messages`    | Conversation history in OpenAI format          |
+| `stream`      | Fixed `true`, requires streaming response      |
+| `temperature` | Sampling temperature                           |
+| `max_tokens`  | Maximum generation length                      |
+| `device_id`   | Custom parameter, passed through from `LLMConfig.Custom` |
+
 ### Response Format
 
-The response must follow the OpenAI SSE format and end with `data: [DONE]`.
+Response must follow OpenAI SSE format:
 
-Official documentation:
- [CustomLLM Integration](https://www.volcengine.com/docs/6348/1399966)
+```
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"model":"qwen-flash","created":1704355200}
+
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}],"model":"qwen-flash","created":1704355200}
+
+data: {"id":"resp-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"model":"qwen-flash","created":1704355200}
+
+data: [DONE]
+```
+
+**Response requirements**:
+
+- Must return SSE streaming response
+- Content-Type: `text/event-stream`
+- Each line starts with `data: `
+- Last line must be `data: [DONE]`
+
+Official documentation: [CustomLLM Integration](https://www.volcengine.com/docs/6348/1399966)
 
 ## RTC Token
 
@@ -459,10 +473,10 @@ Clients need a token to join an RTC room. Tokens are generated server-side using
 Token = Version + AppId + Base64(Message + Signature)
 ```
 
-- Version: fixed value `001`
-- AppId: 24-character application identifier
-- Message: binary-encoded payload (RoomId, UserId, expiry time, privileges)
-- Signature: HMAC-SHA256 signature using AppKey
+- **Version**: fixed value `001`
+- **AppId**: 24-character application identifier
+- **Message**: binary-encoded payload (RoomId, UserId, expiry time, privileges)
+- **Signature**: HMAC-SHA256 signature using AppKey
 
 ### Token Privileges
 
@@ -473,11 +487,11 @@ Token = Version + AppId + Base64(Message + Signature)
 
 ### Validity
 
-Default validity is 24 hours (86,400 seconds).
+Default validity is 24 hours (86,400 seconds). Must be regenerated after expiry.
 
 ### Example
 
-```
+```typescript
 import { AccessToken } from './rtctoken'
 
 const token = new AccessToken(appId, appKey, roomId, userId)
@@ -488,11 +502,13 @@ token.expireTime(expireAt)
 const tokenString = token.serialize()
 ```
 
+For token generation libraries, see [Installation and Testing - Generating an RTC Token](./installation-and-testing.md#generating-an-rtc-token).
+
 ## Error Codes
 
 ### Response Format
 
-```
+```json
 {
   "ResponseMetadata": {
     "RequestId": "xxx",
@@ -535,11 +551,10 @@ const tokenString = token.serialize()
 | `TaskNotExist` | Task does not exist             |
 | `InvalidToken` | RTC token is invalid or expired |
 
-Official documentation:
- [Common Error Codes](https://www.volcengine.com/docs/6369/68677)
+Official documentation: [Common Error Codes](https://www.volcengine.com/docs/6369/68677)
 
 ## Related Resources
 
 - [Installation and Testing](./installation-and-testing.md)
-- [Volcano Engine Real-Time Conversational API Documentation](https://www.volcengine.com/docs/6348/1315560)
+- [Volcano Engine Real-Time Conversational API Documentation](https://www.volcengine.com/docs/6348/1315560) - Official complete documentation
 - [Volcano Engine Real-Time Audio and Video Documentation](https://www.volcengine.com/docs/6348)

--- a/ja_JP/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/ja_JP/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -4,8 +4,7 @@ This document explains how to integrate Volcano Engine speech services and compl
 
 ## Prerequisites
 
-Before starting integration, make sure you have enabled the required Volcano Engine services and configured credentials. For detailed steps, see
- Quick Start – Volcano Engine Credentials.
+Before starting integration, make sure you have enabled the required Volcano Engine services and configured credentials. For detailed steps, see [Quick Start – Volcano Engine Credentials](./quick-start.md#4-volcano-engine-credentials).
 
 Required credentials:
 
@@ -24,29 +23,29 @@ The proxy service is responsible for:
 
 - Generating RTC tokens using `AppKey`
 - Calling Volcano Engine OpenAPI using `AccessKey`
-- Returning tokens and room information to the client
+- Returning `Token` and room information to the client
 
 ### Generating an RTC Token
 
-RTC tokens are generated using `AppKey` with the HMAC-SHA256 algorithm. Volcano Engine provides reference implementations in multiple languages:
+`Token` is generated using `AppKey` with the HMAC-SHA256 algorithm:
 
 | Language      | Reference Implementation                                     |
 | ------------- | ------------------------------------------------------------ |
 | Node.js / Bun | [token.ts](https://github.com/emqx/mcp-ai-companion-demo/tree/volcengine/rtc/volc-server/src/lib/token.ts) |
 
-```
+```typescript
 import { AccessToken, Privileges } from './rtctoken'
 
 const token = new AccessToken(appId, appKey, roomId, userId)
 token.addPrivilege(Privileges.PrivPublishStream, expireTime)
-const tokenString = token.serialize() // Return to the client
+const tokenString = token.serialize()  // Return to the client
 ```
 
 ### Calling Volcano Engine OpenAPI
 
-APIs such as `StartVoiceChat` and `StopVoiceChat` must be signed using `AccessKeyId` and `SecretKey`. The official OpenAPI SDK handles signing automatically:
+APIs such as `StartVoiceChat` and `StopVoiceChat` require V4 signing using `AccessKeyId` and `SecretKey`. The official OpenAPI SDK provides a `Signer` class to generate the required headers:
 
-```
+```bash
 # Node.js / Bun
 npm install @volcengine/openapi
 
@@ -55,45 +54,79 @@ pip install volcengine-python-sdk
 
 # Go
 go get github.com/volcengine/volc-sdk-golang
+```
+
+```typescript
 // Node.js example
 import { Signer } from '@volcengine/openapi'
 
-const signer = new Signer(
-  {
-    accessKeyId: process.env.ACCESS_KEY_ID,
-    secretKey: process.env.SECRET_KEY,
-  },
-  'rtc'
-)
+const body = { AppId: appId, RoomId: roomId, /* ... */ }
 
-const response = await signer.fetch('https://rtc.volcengineapi.com', {
+// Build the request data
+const openApiRequestData = {
+  region: 'cn-north-1',
   method: 'POST',
-  query: { Action: 'StartVoiceChat', Version: '2024-12-01' },
-  body: { AppId: appId, RoomId: roomId, ... },
+  params: {
+    Action: 'StartVoiceChat',
+    Version: '2024-12-01',
+  },
+  headers: {
+    Host: 'rtc.volcengineapi.com',
+    'Content-Type': 'application/json',
+  },
+  body,
+}
+
+// Create Signer and add authorization headers
+const signer = new Signer(openApiRequestData, 'rtc')
+signer.addAuthorization({
+  accessKeyId: process.env.ACCESS_KEY_ID,
+  secretKey: process.env.SECRET_KEY,
 })
-// response includes Token, RoomId, UserId, etc., which are returned to the client
+
+// Send the request (headers now include the signature)
+const response = await fetch(
+  'https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01',
+  {
+    method: 'POST',
+    headers: openApiRequestData.headers,
+    body: JSON.stringify(body),
+  }
+)
 ```
 
-For detailed signing rules, see
- [Volcano Engine V4 Signature Algorithm](https://www.volcengine.com/docs/6369/67269).
+For detailed signing rules, see [Volcano Engine V4 Signature Algorithm](https://www.volcengine.com/docs/6369/67269).
 
 ### Example API Design
 
 The proxy service should expose APIs for client use:
 
-```
-// Start a voice session – returns token and room info
+```typescript
+// Get scene configuration – returns Token and room info
+GET /api/scenes
+Response: {
+  scenes: [{
+    id: string,
+    rtcConfig: { appId: string, roomId: string, userId: string, token: string }
+  }]
+}
+
+// Start a voice session
 POST /api/voice/start
 Request:  { sceneId: string }
-Response: { roomId: string, token: string, userId: string, appId: string }
+Response: { success: boolean }
 
 // Stop a voice session
 POST /api/voice/stop
-Request:  { roomId: string }
+Request:  { sceneId: string }
 Response: { success: boolean }
 ```
 
-Internally, these endpoints call the Volcano Engine OpenAPI (`StartVoiceChat`, `StopVoiceChat`) and pass the returned token and related information back to the client.
+Server-side implementation notes:
+
+- **Scene configuration**: The server generates a `roomId` (UUID) and `userId` for each scene at initialization, and uses `AppKey` to generate the corresponding RTC Token (valid for 24 hours). Clients retrieve this information via `/api/scenes` to join the RTC room.
+- **Token usage**: Clients pass the Token to the RTC SDK's `joinRoom` method for authentication.
+- **Starting/stopping voice sessions**: The server looks up the scene configuration by `sceneId`, retrieves `roomId` and other parameters, then calls the Volcano Engine OpenAPI (`StartVoiceChat`, `StopVoiceChat`).
 
 ## Web Integration
 
@@ -103,7 +136,7 @@ Volcano Engine provides the `@volcengine/rtc` SDK for Web integration. The inter
 
 ### Install the SDK
 
-```
+```bash
 npm install @volcengine/rtc
 ```
 
@@ -111,40 +144,45 @@ For AI noise reduction, the SDK includes the `@volcengine/rtc/extension-ainr` ex
 
 ### Basic Integration Flow
 
-#### 1. Call the Server API to Get a Token
+#### 1. Get Scene Configuration
 
-Before using the RTC SDK, call the server API to start a voice session and retrieve the token and room information:
+Before using the RTC SDK, call the server API to get the scene configuration, including the Token and room information:
 
-```
-const response = await fetch('/api/voice/start', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ sceneId: 'your-scene-id' }),
-})
+```typescript
+// Call the server API to get scene configuration
+const response = await fetch('/api/scenes')
+const { scenes } = await response.json()
 
-const { appId, roomId, token, userId } = await response.json()
+// Select the target scene
+const scene = scenes.find(s => s.id === 'your-scene-id') || scenes[0]
+const { appId, roomId, token, userId } = scene.rtcConfig
 ```
 
 #### 2. Create the RTC Engine
 
-```
+```typescript
 import VERTC, { RoomProfileType, MediaType } from '@volcengine/rtc'
 
+// Create engine instance using the appId from the server
 const engine = VERTC.createEngine(appId)
 ```
 
 #### 3. Register Event Listeners
 
-```
+```typescript
+// Listen for errors
 engine.on(VERTC.events.onError, (event) => {
   console.error('RTC error:', event.errorCode)
 })
 
+// Listen for remote user publishing stream (AI voice response)
 engine.on(VERTC.events.onUserPublishStream, async (event) => {
   const { userId, mediaType } = event
+  // Subscribe to remote audio stream
   await engine.subscribeStream(userId, mediaType)
 })
 
+// Listen for binary messages (subtitles, status, etc.)
 engine.on(VERTC.events.onRoomBinaryMessageReceived, (event) => {
   const { message } = event
   // message is an ArrayBuffer in TLV format
@@ -154,12 +192,13 @@ engine.on(VERTC.events.onRoomBinaryMessageReceived, (event) => {
 
 #### 4. Join the Room
 
-```
+```typescript
+// Use token, roomId, userId from step 1 to join the room
 await engine.joinRoom(
   token,
   roomId,
   {
-    userId,
+    userId: userId,
     extraInfo: JSON.stringify({
       call_scene: 'RTC-AIGC',
       user_name: userId,
@@ -175,41 +214,69 @@ await engine.joinRoom(
 
 #### 5. Start the Microphone and Publish Audio
 
-```
+```typescript
+// Start microphone capture
 await engine.startAudioCapture()
+
+// Publish audio stream to the room
 await engine.publishStream(MediaType.AUDIO)
+```
+
+#### 6. Start Voice Session
+
+After publishing the audio stream, call the server API to start the AI voice session:
+
+```typescript
+// Start voice session
+await fetch('/api/voice/start', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ sceneId: scene.id }),
+})
 ```
 
 At this point, voice interaction begins. User speech is recognized by ASR, processed by the LLM, and played back via TTS.
 
-#### 6. Leave the Room
+#### 7. Leave the Room
 
-```
+```typescript
+// Stop publishing
 await engine.unpublishStream(MediaType.AUDIO)
+
+// Stop capture
 await engine.stopAudioCapture()
+
+// Leave the room
 await engine.leaveRoom()
+
+// Destroy the engine
 VERTC.destroyEngine(engine)
 
+// Call server API to stop the voice session
 await fetch('/api/voice/stop', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ roomId }),
+  body: JSON.stringify({ sceneId: scene.id }),
 })
 ```
 
 ### AI Noise Reduction (Optional)
 
-The RTC SDK includes built-in AI noise reduction:
+The Volcano Engine RTC SDK includes built-in AI noise reduction extension to effectively filter environmental noise:
 
-```
+```typescript
 import RTCAIAnsExtension, { AnsMode } from '@volcengine/rtc/extension-ainr'
 
+// Create and register extension
 const aiAnsExtension = new RTCAIAnsExtension()
 engine.registerExtension(aiAnsExtension)
 
+// Check if supported
 const supported = await aiAnsExtension.isSupported()
 if (supported) {
+  // Set noise reduction mode: LOW / MEDIUM / HIGH
   await aiAnsExtension.setAnsMode(AnsMode.MEDIUM)
+  // Enable noise reduction
   aiAnsExtension.enable()
 }
 ```
@@ -218,20 +285,19 @@ if (supported) {
 
 After subscribing to a remote stream, you can obtain a `MediaStream` for playback:
 
-```
+```typescript
 import { StreamIndex } from '@volcengine/rtc'
 
-const audioTrack = engine.getRemoteStreamTrack(
-  userId,
-  StreamIndex.STREAM_INDEX_MAIN,
-  'audio'
-)
+// Get remote user's audio track
+const audioTrack = engine.getRemoteStreamTrack(userId, StreamIndex.STREAM_INDEX_MAIN, 'audio')
 
+// Create MediaStream and play
 const stream = new MediaStream()
 if (audioTrack) {
   stream.addTrack(audioTrack)
 }
 
+// Bind to audio element for playback
 const audioElement = document.querySelector('audio')
 audioElement.srcObject = stream
 ```
@@ -265,7 +331,9 @@ Embedded Linux, RTOS, Android, and other hardware platforms are supported. Hardw
 
 ### Verify RTC Connection
 
-```
+After successfully joining a room, you can confirm via events:
+
+```typescript
 engine.on(VERTC.events.onUserJoined, (event) => {
   console.log('User joined:', event.userInfo.userId)
 })
@@ -304,7 +372,7 @@ AI responses are played via the remote audio stream. Ensure that:
 | --------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | StartVoiceChat fails                    | Signature error or missing parameters                        | Verify API signature and required parameters                 |
 | `The task has been started` error       | Repeated calls with fixed RoomId/UserId                      | Call StopVoiceChat first, then StartVoiceChat again          |
-| Stuck at “AI preparing”                 | Permissions missing / parameter errors / insufficient balance | 1) Check console permissions 2) Verify parameter types and casing 3) Ensure services are enabled and account balance is sufficient |
+| Stuck at "AI preparing"                 | Permissions missing / parameter errors / insufficient balance | 1) Check console permissions 2) Verify parameter types and casing 3) Ensure services are enabled and account balance is sufficient |
 | Digital avatar stuck in preparing state | Concurrency limit or configuration error                     | Verify avatar AppId/Token and ensure concurrency limits are not exceeded |
 
 #### Devices and Media

--- a/zh_CN/emqx-ai/rtc-services/volcengine-rtc/api.md
+++ b/zh_CN/emqx-ai/rtc-services/volcengine-rtc/api.md
@@ -2,13 +2,21 @@
 
 本文档介绍火山引擎实时对话式 AI 的核心 API，包括 StartVoiceChat、UpdateVoiceChat、StopVoiceChat 及相关配置参数。
 
+## API 概览
+
+| API | 说明 |
+|-----|------|
+| [StartVoiceChat](#startvoicechat) | 启动 AI 语音会话，在指定房间中创建 AI 智能体 |
+| [StopVoiceChat](#stopvoicechat) | 停止语音会话，释放 AI 智能体资源 |
+| [UpdateVoiceChat](#updatevoicechat) | 更新进行中的语音会话（打断、自定义播报等） |
+
+所有 API 均需要使用 AccessKey 进行 V4 签名，参考 [认证代理服务](./installation-and-testing.md#认证代理服务)。
+
 ## StartVoiceChat
 
-启动语音会话，返回 RTC 连接凭证。
+启动 AI 语音会话，在指定房间中创建 AI 智能体。
 
 **请求地址**：`POST https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01`
-
-**请求头**：需要使用 AccessKey 进行签名，参考 [认证代理服务](./installation-and-testing.md#认证代理服务)。
 
 ### 请求参数
 
@@ -17,8 +25,8 @@
 | `AppId` | string | 是 | RTC 应用 ID |
 | `RoomId` | string | 是 | 房间 ID |
 | `TaskId` | string | 是 | 任务 ID，用于标识会话 |
-| `AgentConfig` | object | 是 | 智能体配置 |
-| `Config` | object | 是 | 会话配置，包含 ASR、TTS、LLM 等参数 |
+| `AgentConfig` | object | 是 | 智能体配置，见下方 |
+| `Config` | object | 是 | 会话配置，包含 ASR、TTS、LLM 等参数，见下方 |
 
 ### AgentConfig
 
@@ -26,38 +34,22 @@
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `TargetUserId` | string[] | 是 | 目标用户 ID 列表 |
-| `UserId` | string | 是 | 智能体用户 ID |
-| `WelcomeMessage` | string | 否 | 欢迎语 |
-| `EnableConversationStateCallback` | boolean | 否 | 启用会话状态回调 |
-| `AnsMode` | number | 否 | 降噪模式（0-3） |
-| `VoicePrint` | object | 否 | 声纹识别配置 |
-
-**VoicePrint 配置**：
-
-| 参数 | 类型 | 说明 |
-|------|------|------|
-| `Mode` | number | 声纹识别模式（0: 关闭, 1: 开启） |
-| `IdList` | string[] | 声纹 ID 列表 |
+| `TargetUserId` | string[] | 是 | 目标用户 ID 列表，即客户端用户 ID |
+| `UserId` | string | 是 | 智能体用户 ID（AI Bot 的身份标识） |
+| `WelcomeMessage` | string | 否 | 欢迎语，会话开始时自动播报 |
+| `EnableConversationStateCallback` | boolean | 否 | 启用会话状态回调，用于接收 listening/thinking/speaking 状态 |
+| `AnsMode` | number | 否 | AI 降噪模式（0: 关闭, 1: 低, 2: 中, 3: 高，推荐 3） |
+| `VoicePrint` | object | 否 | 声纹识别配置：`Mode`（0: 关闭, 1: 开启）、`IdList`（声纹 ID 列表） |
 
 ### Config
 
-会话配置，包含以下子配置：
-
-```json
-{
-  "ASRConfig": { ... },
-  "TTSConfig": { ... },
-  "LLMConfig": { ... },
-  "InterruptMode": 0
-}
-```
+会话配置：
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `ASRConfig` | object | 语音识别配置 |
-| `TTSConfig` | object | 语音合成配置 |
-| `LLMConfig` | object | 大模型配置 |
+| `ASRConfig` | object | 语音识别配置，详见 [ASRConfig](#asrconfig) |
+| `TTSConfig` | object | 语音合成配置，详见 [TTSConfig](#ttsconfig) |
+| `LLMConfig` | object | 大模型配置，详见 [LLMConfig](#llmconfig) |
 | `InterruptMode` | number | 打断模式（0: 语义打断, 1: 手动打断） |
 
 ### 响应
@@ -71,27 +63,21 @@
     "Service": "rtc",
     "Region": "cn-north-1"
   },
-  "Result": {
-    "AppId": "your-app-id",
-    "RoomId": "room-uuid",
-    "UserId": "user-uuid",
-    "Token": "rtc-token..."
-  }
+  "Result": {}
 }
 ```
 
-| 字段 | 说明 |
-|------|------|
-| `Result.AppId` | RTC 应用 ID |
-| `Result.RoomId` | RTC 房间 ID |
-| `Result.UserId` | RTC 用户 ID |
-| `Result.Token` | RTC 访问令牌（24 小时有效） |
+成功时 `Result` 为空对象，失败时 `ResponseMetadata.Error` 包含错误信息。
+
+::: tip 注意
+`StartVoiceChat` 用于在已有房间中启动 AI 智能体，**不返回** RTC Token。Token 需要服务端使用 `AppKey` 自行生成，参考 [生成 RTC Token](./installation-and-testing.md#生成-rtc-token)。
+:::
 
 官方文档：[StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)
 
 ## StopVoiceChat
 
-停止语音会话，释放资源。
+停止语音会话，释放 AI 智能体资源。
 
 **请求地址**：`POST https://rtc.volcengineapi.com?Action=StopVoiceChat&Version=2024-12-01`
 
@@ -99,9 +85,9 @@
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `AppId` | string | 是 | RTC 应用 ID |
-| `RoomId` | string | 是 | 房间 ID |
-| `TaskId` | string | 是 | 任务 ID |
+| `AppId` | string | 是 | RTC 应用 ID，与 StartVoiceChat 一致 |
+| `RoomId` | string | 是 | 房间 ID，与 StartVoiceChat 一致 |
+| `TaskId` | string | 是 | 任务 ID，与 StartVoiceChat 一致 |
 
 ### 响应
 
@@ -115,6 +101,8 @@
   "Result": {}
 }
 ```
+
+成功时 `Result` 为空对象，失败时 `ResponseMetadata.Error` 包含错误信息。
 
 官方文档：[StopVoiceChat](https://www.volcengine.com/docs/6348/1404672)
 
@@ -192,9 +180,15 @@
 }
 ```
 
+成功时 `Result` 为空对象，失败时 `ResponseMetadata.Error` 包含错误信息。
+
 官方文档：[UpdateVoiceChat](https://www.volcengine.com/docs/6348/1404671)
 
-## ASRConfig
+## 配置参数详解
+
+以下配置用于 `StartVoiceChat` 的 `Config` 参数。
+
+### ASRConfig
 
 语音识别配置：
 
@@ -207,7 +201,7 @@
 | `TurnDetectionMode` | number | 否 | 轮次检测模式 |
 | `InterruptConfig` | object | 否 | 打断配置 |
 
-### ProviderParams
+**ProviderParams**：
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
@@ -218,9 +212,7 @@
 | `boosting_table_id` | string | 热词表 ID |
 | `correct_table_id` | string | 纠错表 ID |
 
-### VADConfig
-
-语音活动检测配置：
+**VADConfig**（语音活动检测）：
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
@@ -231,9 +223,7 @@
 | `Sensitivity` | number | 灵敏度 |
 | `AIVAD` | boolean | 是否启用 AI VAD |
 
-### InterruptConfig
-
-打断配置：
+**InterruptConfig**（打断配置）：
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
@@ -262,7 +252,7 @@
 }
 ```
 
-## TTSConfig
+### TTSConfig
 
 语音合成配置：
 
@@ -272,7 +262,7 @@
 | `ProviderParams` | object | 是 | 提供商参数 |
 | `IgnoreBracketText` | number[] | 否 | 忽略的括号类型 |
 
-### ProviderParams
+**ProviderParams**：
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
@@ -291,14 +281,25 @@
 
 **audio 配置**：
 
-| 参数 | 类型 | 说明 | 范围 |
-|------|------|------|------|
-| `voice_type` | string | 音色类型 | 见下方音色列表 |
-| `speed_ratio` | number | 语速比例 | 0.5-2.0，默认 `1.0` |
-| `pitch_ratio` | number | 音调比例 | 0.5-2.0，默认 `1.0` |
-| `volume_ratio` | number | 音量比例 | 0.5-2.0，默认 `1.0` |
-| `emotion` | string | 情感类型 | `happy`、`sad`、`angry`、`neutral` |
-| `emotion_strength` | number | 情感强度 | 0.0-1.0，默认 `0.8` |
+不同 TTS 模式下的参数略有不同：
+
+| 参数 | 类型 | 说明 | 适用模式 |
+|------|------|------|----------|
+| `voice_type` | string | 音色类型 | 所有模式 |
+| `volume_ratio` | number | 音量比例（0.5-2.0） | 所有模式 |
+| `speed_ratio` | number | 语速比例（0.5-2.0） | standard |
+| `pitch_ratio` | number | 音调比例（0.5-2.0） | standard |
+| `speech_ratio` | number | 语速比例（0.5-2.0） | bigtts |
+| `pitch_rate` | number | 音调变化率 | bigtts |
+| `speech_rate` | number | 语速变化率 | bidirection |
+| `emotion` | string | 情感类型：`happy`、`sad`、`angry`、`neutral` | 支持情感的音色 |
+| `emotion_strength` | number | 情感强度（0.0-1.0） | 配合 emotion 使用 |
+
+::: tip TTS 模式说明
+- `standard`：标准模式，使用 `speed_ratio`、`pitch_ratio`
+- `bigtts`：大模型 TTS，使用 `speech_ratio`、`pitch_rate`
+- `bidirection`：双向流式，使用 `speech_rate`，支持 `Additions` 配置
+:::
 
 **常用音色**：
 
@@ -335,7 +336,7 @@
 }
 ```
 
-## LLMConfig
+### LLMConfig
 
 大模型配置：
 
@@ -353,21 +354,10 @@
 | `MaxTokens` | number | 否 | 最大生成 token 数，默认 `256` |
 | `HistoryLength` | number | 否 | 保留的历史轮数，默认 `15` |
 | `EnableRoundId` | boolean | 否 | 启用轮次 ID |
-| `VisionConfig` | object | 否 | 视觉理解配置 |
+| `VisionConfig` | object | 否 | 视觉理解配置：`Enable`（是否启用）、`SnapshotConfig`（截图配置） |
 | `Custom` | string | 否 | 自定义参数（JSON 字符串），透传给 CustomLLM |
 
-### VisionConfig
-
-视觉理解配置：
-
-| 参数 | 类型 | 说明 |
-|------|------|------|
-| `Enable` | boolean | 是否启用视觉理解 |
-| `SnapshotConfig` | object | 截图配置 |
-
-### UserPrompts
-
-预设对话历史，用于引导对话风格：
+**UserPrompts**（预设对话历史）：
 
 ```json
 [
@@ -568,4 +558,3 @@ Token 生成库参考 [安装与测试 - 生成 RTC Token](./installation-and-te
 - [安装与测试](./installation-and-testing.md)
 - [火山引擎实时对话式 API 文档](https://www.volcengine.com/docs/6348/1315560) - 官方完整文档
 - [火山引擎实时音视频文档](https://www.volcengine.com/docs/6348)
-

--- a/zh_CN/emqx-ai/rtc-services/volcengine-rtc/api.md
+++ b/zh_CN/emqx-ai/rtc-services/volcengine-rtc/api.md
@@ -25,8 +25,8 @@
 | `AppId` | string | 是 | RTC 应用 ID |
 | `RoomId` | string | 是 | 房间 ID |
 | `TaskId` | string | 是 | 任务 ID，用于标识会话 |
-| `AgentConfig` | object | 是 | 智能体配置，见下方 |
-| `Config` | object | 是 | 会话配置，包含 ASR、TTS、LLM 等参数，见下方 |
+| `AgentConfig` | object | 是 | 智能体配置，详见 [AgentConfig](#agentconfig) |
+| `Config` | object | 是 | 会话配置，包含 ASR、TTS、LLM 等参数，详见 [Config](#config) |
 
 ### AgentConfig
 
@@ -70,7 +70,7 @@
 成功时 `Result` 为空对象，失败时 `ResponseMetadata.Error` 包含错误信息。
 
 ::: tip 注意
-`StartVoiceChat` 用于在已有房间中启动 AI 智能体，**不返回** RTC Token。Token 需要服务端使用 `AppKey` 自行生成，参考 [生成 RTC Token](./installation-and-testing.md#生成-rtc-token)。
+`StartVoiceChat` 用于在已有房间中启动 AI 智能体。
 :::
 
 官方文档：[StartVoiceChat](https://www.volcengine.com/docs/6348/1404673)

--- a/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -42,7 +42,7 @@ const tokenString = token.serialize()  // 返回给客户端
 
 ### 调用火山引擎 OpenAPI
 
-`StartVoiceChat`、`StopVoiceChat` 等 API 需要使用 `AccessKeyId` 和 `SecretKey` 签名。使用官方 OpenAPI SDK 可以自动处理签名：
+`StartVoiceChat`、`StopVoiceChat` 等 API 需要使用 `AccessKeyId` 和 `SecretKey` 进行 V4 签名。官方 OpenAPI SDK 提供 `Signer` 类帮助生成签名头：
 
 ```bash
 # Node.js / Bun
@@ -59,17 +59,39 @@ go get github.com/volcengine/volc-sdk-golang
 // Node.js 示例
 import { Signer } from '@volcengine/openapi'
 
-const signer = new Signer({
+const body = { AppId: appId, RoomId: roomId, /* ... */ }
+
+// 构造请求数据
+const openApiRequestData = {
+  region: 'cn-north-1',
+  method: 'POST',
+  params: {
+    Action: 'StartVoiceChat',
+    Version: '2024-12-01',
+  },
+  headers: {
+    Host: 'rtc.volcengineapi.com',
+    'Content-type': 'application/json',
+  },
+  body,
+}
+
+// 创建 Signer 并添加认证头
+const signer = new Signer(openApiRequestData, 'rtc')
+signer.addAuthorization({
   accessKeyId: process.env.ACCESS_KEY_ID,
   secretKey: process.env.SECRET_KEY,
-}, 'rtc')
-
-const response = await signer.fetch('https://rtc.volcengineapi.com', {
-  method: 'POST',
-  query: { Action: 'StartVoiceChat', Version: '2024-12-01' },
-  body: { AppId: appId, RoomId: roomId, ... },
 })
-// response 包含 Token、RoomId、UserId 等信息，返回给客户端
+
+// 发起请求（headers 已包含签名）
+const response = await fetch(
+  'https://rtc.volcengineapi.com?Action=StartVoiceChat&Version=2024-12-01',
+  {
+    method: 'POST',
+    headers: openApiRequestData.headers,
+    body: JSON.stringify(body),
+  }
+)
 ```
 
 详细签名规范参考：[火山引擎 V4 签名算法](https://www.volcengine.com/docs/6369/67269)
@@ -79,18 +101,31 @@ const response = await signer.fetch('https://rtc.volcengineapi.com', {
 代理服务需要暴露接口供客户端调用：
 
 ```typescript
-// 启动语音会话 - 返回 Token 和房间信息
+// 获取场景配置 - 返回 Token 和房间信息
+GET /api/scenes
+Response: {
+  scenes: [{
+    id: string,
+    rtcConfig: { appId: string, roomId: string, userId: string, token: string }
+  }]
+}
+
+// 启动语音会话
 POST /api/voice/start
 Request:  { sceneId: string }
-Response: { roomId: string, token: string, userId: string, appId: string }
+Response: { success: boolean }
 
 // 停止语音会话
 POST /api/voice/stop
-Request:  { roomId: string }
+Request:  { sceneId: string }
 Response: { success: boolean }
 ```
 
-服务端实现中，这些接口内部调用火山引擎 OpenAPI（`StartVoiceChat`、`StopVoiceChat`），并将返回的 Token 等信息透传给客户端。
+服务端实现说明：
+
+- **场景配置**：服务端在初始化时为每个场景生成 `roomId`（UUID）和 `userId`，并使用 `AppKey` 生成对应的 RTC Token（24 小时有效）。客户端通过 `/api/scenes` 获取这些信息用于加入 RTC 房间。
+- **Token 用途**：客户端调用 RTC SDK 的 `joinRoom` 方法时需要传入 Token 进行身份认证。
+- **启动/停止语音会话**：服务端根据 `sceneId` 查找对应的场景配置，获取 `roomId` 等参数后调用火山引擎 OpenAPI（`StartVoiceChat`、`StopVoiceChat`）。
 
 ## Web 端集成
 
@@ -108,19 +143,18 @@ npm install @volcengine/rtc
 
 ### 基础集成流程
 
-#### 1. 调用服务端 API 获取 Token
+#### 1. 获取场景配置
 
-使用 RTC SDK 前，先调用服务端接口启动语音会话，获取 Token 和房间信息：
+使用 RTC SDK 前，先调用服务端接口获取场景配置，包含 Token 和房间信息：
 
 ```typescript
-// 调用服务端 API 获取认证信息
-const response = await fetch('/api/voice/start', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ sceneId: 'your-scene-id' }),
-})
+// 调用服务端 API 获取场景配置
+const response = await fetch('/api/scenes')
+const { scenes } = await response.json()
 
-const { appId, roomId, token, userId } = await response.json()
+// 选择目标场景
+const scene = scenes.find(s => s.id === 'your-scene-id') || scenes[0]
+const { appId, roomId, token, userId } = scene.rtcConfig
 ```
 
 #### 2. 创建 RTC 引擎
@@ -187,9 +221,22 @@ await engine.startAudioCapture()
 await engine.publishStream(MediaType.AUDIO)
 ```
 
+#### 6. 启动语音会话
+
+发布音频流后，调用服务端 API 启动 AI 语音会话：
+
+```typescript
+// 启动语音会话
+await fetch('/api/voice/start', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ sceneId: scene.id }),
+})
+```
+
 此时语音交互已经开始，用户说话会被 ASR 识别，LLM 处理后通过 TTS 播放回复。
 
-#### 6. 离开房间
+#### 7. 离开房间
 
 ```typescript
 // 停止发布
@@ -208,7 +255,7 @@ VERTC.destroyEngine(engine)
 await fetch('/api/voice/stop', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ roomId }),
+  body: JSON.stringify({ sceneId: scene.id }),
 })
 ```
 

--- a/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
+++ b/zh_CN/emqx-ai/rtc-services/volcengine-rtc/installation-and-testing.md
@@ -22,11 +22,11 @@
 代理服务负责：
 - 使用 `AppKey` 生成 RTC Token
 - 使用 `AccessKey` 调用火山引擎 OpenAPI
-- 将 Token 和房间信息返回给客户端
+- 将 `Token` 和房间信息返回给客户端
 
 ### 生成 RTC Token
 
-Token 使用 `AppKey` 通过 HMAC-SHA256 算法生成。火山引擎提供各语言的生成库：
+`Token` 使用 `AppKey` 通过 HMAC-SHA256 算法生成：
 
 | 语言 | 参考实现 |
 |------|----------|
@@ -71,7 +71,7 @@ const openApiRequestData = {
   },
   headers: {
     Host: 'rtc.volcengineapi.com',
-    'Content-type': 'application/json',
+    'Content-Type': 'application/json',
   },
   body,
 }


### PR DESCRIPTION
- Fix StartVoiceChat response example (Result is empty, not Token/RoomId)
- Correct Signer API usage (addAuthorization instead of fetch)
- Update API design example (use /api/scenes for config, not /api/voice/start)
- Restructure api.md with proper hierarchy (Configuration Details section)
- Add 7-step integration flow with correct sequence
- Add TTS mode explanations (standard/bigtts/bidirection)