### PR TITLE
docs: add HTTP API metrics for Prometheus (e4.4.34)

### DIFF
--- a/en_US/tutorial/prometheus.md
+++ b/en_US/tutorial/prometheus.md
@@ -51,18 +51,16 @@ Prometheus Server → scrape → EMQX HTTP endpoint
 Configure Prometheus to scrape the following endpoint:
 
 ```
-http://localhost:8081/api/v4/emqx_prometheus
+http://localhost:8081/api/v4/emqx_prometheus?type=prometheus
 ```
+
+> Note: The default response format is JSON (`type=json`). Add `?type=prometheus` to get Prometheus text format.
 
 ## HTTP API Metrics
 
 > Available since EMQX Enterprise e4.4.34.
 
-Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are automatically included in the `emqx_prometheus` plugin data collection without additional configuration:
-
-- **Push mode**: Metrics are periodically pushed to the PushGateway along with other metrics.
-- **Pull mode**: Available via `GET /api/v4/emqx_prometheus?type=prometheus`, which returns data in Prometheus text format.
-- **JSON mode**: Available via `GET /api/v4/emqx_prometheus` (default `type=json`), which returns counter data in JSON format.
+Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are automatically included in the `emqx_prometheus` plugin data collection without additional configuration, and are available via both push mode and pull mode.
 
 ### Metrics
 

--- a/en_US/tutorial/prometheus.md
+++ b/en_US/tutorial/prometheus.md
@@ -58,7 +58,13 @@ http://localhost:8081/api/v4/emqx_prometheus
 
 > Available since EMQX Enterprise e4.4.34.
 
-Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are available through both push mode and pull mode.
+Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are automatically included in the `emqx_prometheus` plugin data collection without additional configuration:
+
+- **Push mode**: Metrics are periodically pushed to the PushGateway along with other metrics.
+- **Pull mode**: Available via `GET /api/v4/emqx_prometheus?type=prometheus`, which returns data in Prometheus text format.
+- **JSON mode**: Available via `GET /api/v4/emqx_prometheus` (default `type=json`), which returns counter data in JSON format.
+
+### Metrics
 
 | Name | Type | Labels | Description |
 | ---- | ---- | ------ | ----------- |

--- a/en_US/tutorial/prometheus.md
+++ b/en_US/tutorial/prometheus.md
@@ -62,6 +62,12 @@ http://localhost:8081/api/v4/emqx_prometheus?type=prometheus
 
 Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are automatically included in the `emqx_prometheus` plugin data collection without additional configuration, and are available via both push mode and pull mode.
 
+To query the request counter directly in JSON format, use:
+
+```
+GET /api/v4/http_api_metrics
+```
+
 ### Metrics
 
 | Name | Type | Labels | Description |

--- a/en_US/tutorial/prometheus.md
+++ b/en_US/tutorial/prometheus.md
@@ -28,3 +28,61 @@ The configuration file is located in `etc/plugins/emqx_statsd.conf`, where:
 The `emqx_statsd` plugin provides Grafana ’s Dashboard template files. These templates contain the display of all EMQX Broker monitoring data. Users can directly import them into Grafana and select icons that display the monitoring status of EMQX Broker.
 
 The template file is located:[emqx_statsd/grafana_template](https://github.com/emqx/emqx-statsd/tree/master/grafana_template)。
+
+{% emqxee %}
+
+## HTTP API Metrics
+
+> Available since EMQX Enterprise e4.4.34.
+
+EMQX Enterprise exposes HTTP API request metrics through the Prometheus endpoint. These metrics help monitor the health and performance of the REST API.
+
+### Metrics
+
+| Name | Type | Labels | Description |
+| ---- | ---- | ------ | ----------- |
+| `emqx_http_api_request_total` | Counter | `result`=`success` \| `failure` | Total number of HTTP API requests |
+| `emqx_http_api_request_duration_milliseconds` | Histogram | None | HTTP API request duration distribution (milliseconds) |
+
+### Result Classification
+
+The `result` label of `emqx_http_api_request_total` is classified as follows:
+
+- **success**: HTTP status code is 200 and business response code is `code=0`.
+- **failure**: All other cases, including:
+  - Authentication failure (HTTP 401)
+  - Route not found (HTTP 404)
+  - Server error (HTTP 500)
+  - Non-zero business error code
+  - Permission denied
+
+### Duration Histogram Buckets
+
+`emqx_http_api_request_duration_milliseconds` uses the following bucket boundaries (in milliseconds):
+
+`5, 10, 25, 50, 100, 250, 500, 1000`
+
+### Prometheus Queries
+
+```promql
+# API request rate (requests per second)
+rate(emqx_http_api_request_total[5m])
+
+# Request rate grouped by result
+sum by (result) (rate(emqx_http_api_request_total[5m]))
+
+# Failure rate
+sum(rate(emqx_http_api_request_total{result="failure"}[5m]))
+/
+sum(rate(emqx_http_api_request_total[5m]))
+
+# P99 request duration
+histogram_quantile(0.99, rate(emqx_http_api_request_duration_milliseconds_bucket[5m]))
+
+# Average request duration
+rate(emqx_http_api_request_duration_milliseconds_sum[5m])
+/
+rate(emqx_http_api_request_duration_milliseconds_count[5m])
+```
+
+{% endemqxee %}

--- a/en_US/tutorial/prometheus.md
+++ b/en_US/tutorial/prometheus.md
@@ -1,43 +1,64 @@
 # Prometheus
 
-EMQX Broker provides [emqx_statsd](https://github.com/emqx/emqx-statsd) plug-in, which is used to output the monitoring data of the system to the third-party monitoring system.
-
-Take  [Prometheus](https://prometheus.io) as an example:
-
-`emqx_statsd` supports pushing data to Pushgateway, which is then pulled by Promethues Server for storage.
-
-::: tip Tip
-`emqx_statsd` does not support the pull operation of Prometheus.
-:::
-
-## Configuration
-
-The `emqx_statsd` plugin internally starts a timer to collect the monitoring data in EMQX Broker every interval.
-
-For the specific fields and meanings of the monitoring data pushed by `emqx_statsd`, see [Metrics & Stats](../advanced/metrics-and-stats.md)
-
-The configuration file is located in `etc/plugins/emqx_statsd.conf`, where:
-
-| Configuration       | Type    | Optional value | Default value         | Description                     |
-| ------------------- | ------- | -------------- | --------------------- | ------------------------------- |
-| push.gateway.server | string  | -              | http://127.0.0.1:9091 | Prometheus' PushGateway address |
-| interval            | integer | > 0            | 5000                  | Push interval, unit: ms         |
-
-### Grafana Data template
-
-The `emqx_statsd` plugin provides Grafana ’s Dashboard template files. These templates contain the display of all EMQX Broker monitoring data. Users can directly import them into Grafana and select icons that display the monitoring status of EMQX Broker.
-
-The template file is located:[emqx_statsd/grafana_template](https://github.com/emqx/emqx-statsd/tree/master/grafana_template)。
-
 {% emqxee %}
+
+> Starting from EMQX Enterprise v4.1.0, `emqx_statsd` has been renamed to `emqx_prometheus`. Related plugin names and directory paths have changed accordingly.
+
+EMQX Enterprise supports two ways to integrate with [Prometheus](https://prometheus.io):
+
+- **Push mode** (all versions): The [`emqx_prometheus`](https://github.com/emqx/emqx-prometheus) plugin periodically pushes metrics to Prometheus Pushgateway, which Prometheus Server then scrapes.
+- **Pull mode** (e4.4.34+): Prometheus Server directly scrapes EMQX's built-in HTTP endpoint `/api/v4/emqx_prometheus`, without requiring Pushgateway.
+
+## Push Mode: `emqx_prometheus` Plugin
+
+```
+EMQX → [emqx_prometheus plugin] → Pushgateway → Prometheus Server
+```
+
+The `emqx_prometheus` plugin starts an internal timer that periodically collects EMQX monitoring data and pushes it to Pushgateway.
+
+> Note: The `emqx_prometheus` plugin does not support being scraped directly by Prometheus. Pushgateway is required.
+
+### Enable
+
+Open EMQX Dashboard, go to **Modules**, and add **[EMQX Prometheus Agent](../modules/prometheus.md)**.
+
+### Configuration
+
+Configuration file: `etc/plugins/emqx_prometheus.conf`
+
+| Configuration       | Type    | Default               | Description                      |
+| ------------------- | ------- | --------------------- | -------------------------------- |
+| push.gateway.server | string  | http://127.0.0.1:9091 | Prometheus Pushgateway address   |
+| interval            | integer | 15000                 | Push interval (milliseconds)     |
+
+For the full list of metrics pushed by `emqx_prometheus`, see [Metrics & Stats](../advanced/metrics-and-stats.md).
+
+### Grafana Dashboard
+
+`emqx_prometheus` provides Grafana Dashboard template files that display all EMQX monitoring data. Import them directly into Grafana to visualize EMQX monitoring status.
+
+Template files: [emqx_prometheus/grafana_template](https://github.com/emqx/emqx-prometheus/tree/master/grafana_template)
+
+## Pull Mode: HTTP Endpoint
+
+> Available since EMQX Enterprise e4.4.34.
+
+```
+Prometheus Server → scrape → EMQX HTTP endpoint
+```
+
+Configure Prometheus to scrape the following endpoint:
+
+```
+http://localhost:8081/api/v4/emqx_prometheus
+```
 
 ## HTTP API Metrics
 
 > Available since EMQX Enterprise e4.4.34.
 
-EMQX Enterprise exposes HTTP API request metrics through the Prometheus endpoint. These metrics help monitor the health and performance of the REST API.
-
-### Metrics
+Starting from e4.4.34, EMQX Enterprise exposes two additional metrics for monitoring HTTP API request performance. These metrics are available through both push mode and pull mode.
 
 | Name | Type | Labels | Description |
 | ---- | ---- | ------ | ----------- |
@@ -58,7 +79,7 @@ The `result` label of `emqx_http_api_request_total` is classified as follows:
 
 ### Duration Histogram Buckets
 
-`emqx_http_api_request_duration_milliseconds` uses the following bucket boundaries (in milliseconds):
+`emqx_http_api_request_duration_milliseconds` uses the following bucket boundaries (milliseconds):
 
 `5, 10, 25, 50, 100, 250, 500, 1000`
 

--- a/zh_CN/tutorial/prometheus.md
+++ b/zh_CN/tutorial/prometheus.md
@@ -109,7 +109,13 @@ http://localhost:8081/api/v4/emqx_prometheus
 
 > 从 EMQX Enterprise e4.4.34 开始支持。
 
-从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标可通过推送模式和拉取模式两种方式获取。
+从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标会自动包含在 `emqx_prometheus` 插件的数据采集中，无需额外配置：
+
+- **Push 模式**：指标随插件定时推送至 PushGateway。
+- **Pull 模式**：通过 `GET /api/v4/emqx_prometheus?type=prometheus` 端点拉取，返回 Prometheus text 格式数据。
+- **JSON 模式**：通过 `GET /api/v4/emqx_prometheus`（默认 `type=json`）获取，返回 JSON 格式的计数器数据。
+
+### 指标列表
 
 | 指标名 | 类型 | 标签 | 说明 |
 | ------ | ---- | ---- | ---- |

--- a/zh_CN/tutorial/prometheus.md
+++ b/zh_CN/tutorial/prometheus.md
@@ -55,40 +55,61 @@ EMQX 提供 `emqx_prometheus` 插件，用于将系统的监控数据输出到�
 
 > 从 EMQX Enterprise v4.1.0 开始，emqx_statsd 更名为 emqx_prometheus，相关插件名称、目录均有变更。
 
-EMQX 提供 [emqx_prometheus](https://github.com/emqx/emqx-prometheus) 插件，用于将系统的监控数据输出到第三方的监控系统中。
+EMQX Enterprise 支持两种与 Prometheus 集成的方式：
 
-以 [Prometheus](https://prometheus.io) 为例：
+- **推送模式**（全版本）：[`emqx_prometheus`](https://github.com/emqx/emqx-prometheus) 插件定期将指标推送到 Prometheus Pushgateway，再由 Prometheus Server 拉取。
+- **拉取模式**（e4.4.34+）：Prometheus Server 直接抓取 EMQX 内置的 HTTP 端点 `/api/v4/emqx_prometheus`，无需 Pushgateway。
 
-`emqx_prometheus` 支持将数据推送至 Pushgateway 中，然后再由 Promethues Server 拉取进行存储。
+## 推送模式：`emqx_prometheus` 插件
 
-注意：`emqx_prometheus` 不支持 Prometheus 的 Pull 操作。
+```
+EMQX → [emqx_prometheus 插件] → Pushgateway → Prometheus Server
+```
 
-## 配置
+`emqx_prometheus` 插件内部会启动一个定时器，使其每间隔一段时间便采集 EMQX 中的监控数据，并推送至 Pushgateway。
 
-`emqx_prometheus` 插件内部会启动一个定时器，使其每间隔一段时间便采集 EMQX 中的监控数据。
+> 注意：`emqx_prometheus` 插件不支持被 Prometheus 直接抓取，必须通过 Pushgateway 中转。
 
-`emqx_prometheus` 推送的监控数据包含的具体字段和含义，参见：[Metrics & Stats](../advanced/metrics-and-stats.md)
+### 启用
+
+打开 EMQX Dashboard，进入**模块**页面，添加 **[EMQX Prometheus Agent](../modules/prometheus.md)**。
+
+### 配置
 
 配置文件位于 `etc/plugins/emqx_prometheus.conf`，其中：
 
-|  配置项             | 类型    | 可取值    | 默认值                | 说明                           |
-| ------------------- | ------- | --------- | --------------------- | ------------------------------ |
-| push.gateway.server | string  | -         | http://127.0.0.1:9091 | Prometheus 的 PushGateway 地址 |
-| interval            | integer | > 0       | 5000                  | 推送间隔，单位：毫秒           |
+| 配置项              | 类型    | 默认值                | 说明                           |
+| ------------------- | ------- | --------------------- | ------------------------------ |
+| push.gateway.server | string  | http://127.0.0.1:9091 | Prometheus 的 PushGateway 地址 |
+| interval            | integer | 15000                 | 推送间隔，单位：毫秒           |
+
+`emqx_prometheus` 推送的监控数据包含的具体字段和含义，参见：[Metrics & Stats](../advanced/metrics-and-stats.md)。
 
 ### Grafana 数据模板
 
-`emqx_prometheus` 插件提供了 Grafana 的 Dashboard 的模板文件。这些模板包含了所有 EMQX 监控数据的展示。用户可直接导入到 Grafana 中，进行显示 EMQX 的监控状态的图标。
+`emqx_prometheus` 插件提供了 Grafana 的 Dashboard 模板文件，包含所有 EMQX 监控数据的展示。用户可直接导入到 Grafana 中查看 EMQX 监控状态。
 
-模板文件位于：[emqx_prometheus/grafana_template](https://github.com/emqx/emqx-prometheus/tree/master/grafana_template)。
+模板文件位于：[emqx_prometheus/grafana_template](https://github.com/emqx/emqx-prometheus/tree/master/grafana_template)
+
+## 拉取模式：HTTP 端点
+
+> 从 EMQX Enterprise e4.4.34 开始支持。
+
+```
+Prometheus Server → scrape → EMQX HTTP 端点
+```
+
+在 Prometheus 中配置抓取以下端点：
+
+```
+http://localhost:8081/api/v4/emqx_prometheus
+```
 
 ## HTTP API 监控指标
 
 > 从 EMQX Enterprise e4.4.34 开始支持。
 
-EMQX Enterprise 提供 HTTP API 请求的监控指标，通过 Prometheus 端点自动导出。这些指标可用于监控 REST API 的健康状况和性能表现。
-
-### 指标列表
+从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标可通过推送模式和拉取模式两种方式获取。
 
 | 指标名 | 类型 | 标签 | 说明 |
 | ------ | ---- | ---- | ---- |

--- a/zh_CN/tutorial/prometheus.md
+++ b/zh_CN/tutorial/prometheus.md
@@ -113,6 +113,12 @@ http://localhost:8081/api/v4/emqx_prometheus?type=prometheus
 
 从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标会自动包含在 `emqx_prometheus` 插件的数据采集中，无需额外配置，可通过推送模式和拉取模式两种方式获取。
 
+如需直接以 JSON 格式查询请求计数，可使用以下端点：
+
+```
+GET /api/v4/http_api_metrics
+```
+
 ### 指标列表
 
 | 指标名 | 类型 | 标签 | 说明 |

--- a/zh_CN/tutorial/prometheus.md
+++ b/zh_CN/tutorial/prometheus.md
@@ -82,4 +82,58 @@ EMQX 提供 [emqx_prometheus](https://github.com/emqx/emqx-prometheus) 插件，
 
 模板文件位于：[emqx_prometheus/grafana_template](https://github.com/emqx/emqx-prometheus/tree/master/grafana_template)。
 
+## HTTP API 监控指标
+
+> 从 EMQX Enterprise e4.4.34 开始支持。
+
+EMQX Enterprise 提供 HTTP API 请求的监控指标，通过 Prometheus 端点自动导出。这些指标可用于监控 REST API 的健康状况和性能表现。
+
+### 指标列表
+
+| 指标名 | 类型 | 标签 | 说明 |
+| ------ | ---- | ---- | ---- |
+| `emqx_http_api_request_total` | Counter | `result`=`success` \| `failure` | HTTP API 请求总数 |
+| `emqx_http_api_request_duration_milliseconds` | Histogram | 无 | HTTP API 请求耗时分布（毫秒） |
+
+### 结果分类
+
+`emqx_http_api_request_total` 指标的 `result` 标签按以下规则分类：
+
+- **success**：HTTP 状态码为 200 且业务返回码 `code=0`。
+- **failure**：所有其他情况，包括：
+  - 鉴权失败（HTTP 401）
+  - 路由不存在（HTTP 404）
+  - 服务端异常（HTTP 500）
+  - 业务错误码不为 0
+  - 权限不足（permission denied）
+
+### 耗时直方图
+
+`emqx_http_api_request_duration_milliseconds` 使用以下 bucket 边界（单位：毫秒）：
+
+`5, 10, 25, 50, 100, 250, 500, 1000`
+
+### 在 Prometheus 中查询
+
+```promql
+# 查看 API 请求速率（每秒请求数）
+rate(emqx_http_api_request_total[5m])
+
+# 按结果分组查看请求速率
+sum by (result) (rate(emqx_http_api_request_total[5m]))
+
+# 请求失败率
+sum(rate(emqx_http_api_request_total{result="failure"}[5m]))
+/
+sum(rate(emqx_http_api_request_total[5m]))
+
+# 请求耗时 P99
+histogram_quantile(0.99, rate(emqx_http_api_request_duration_milliseconds_bucket[5m]))
+
+# 请求平均耗时
+rate(emqx_http_api_request_duration_milliseconds_sum[5m])
+/
+rate(emqx_http_api_request_duration_milliseconds_count[5m])
+```
+
 {% endemqxee %}

--- a/zh_CN/tutorial/prometheus.md
+++ b/zh_CN/tutorial/prometheus.md
@@ -102,18 +102,16 @@ Prometheus Server → scrape → EMQX HTTP 端点
 在 Prometheus 中配置抓取以下端点：
 
 ```
-http://localhost:8081/api/v4/emqx_prometheus
+http://localhost:8081/api/v4/emqx_prometheus?type=prometheus
 ```
+
+> 注意：默认响应格式为 JSON（`type=json`），需添加 `?type=prometheus` 参数以获取 Prometheus text 格式数据。
 
 ## HTTP API 监控指标
 
 > 从 EMQX Enterprise e4.4.34 开始支持。
 
-从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标会自动包含在 `emqx_prometheus` 插件的数据采集中，无需额外配置：
-
-- **Push 模式**：指标随插件定时推送至 PushGateway。
-- **Pull 模式**：通过 `GET /api/v4/emqx_prometheus?type=prometheus` 端点拉取，返回 Prometheus text 格式数据。
-- **JSON 模式**：通过 `GET /api/v4/emqx_prometheus`（默认 `type=json`）获取，返回 JSON 格式的计数器数据。
+从 e4.4.34 开始，EMQX Enterprise 新增两个用于监控 HTTP API 请求性能的指标。这些指标会自动包含在 `emqx_prometheus` 插件的数据采集中，无需额外配置，可通过推送模式和拉取模式两种方式获取。
 
 ### 指标列表
 


### PR DESCRIPTION
## Summary

- Add documentation for HTTP API monitoring metrics exposed via Prometheus endpoint, available since EMQX Enterprise e4.4.34.
- Two new metrics documented:
  - `emqx_http_api_request_total` — counter with `result` label (`success` / `failure`)
  - `emqx_http_api_request_duration_milliseconds` — histogram with bucket boundaries at 5, 10, 25, 50, 100, 250, 500, 1000 ms
- Includes result classification rules, histogram bucket explanation, and example PromQL queries.
- Both `zh_CN` and `en_US` versions updated in `tutorial/prometheus.md`.