### PR TITLE
docs: add api-spec endpoints and api_keys CLI command docs

### DIFF
--- a/en_US/admin/api.md
+++ b/en_US/admin/api.md
@@ -2,9 +2,18 @@
 
 EMQX exposes an HTTP management API designed following OpenAPI (Swagger) 3.0 specification.
 
-After EMQX is started, you can visit [http://localhost:18083/api-docs/index.html](http://localhost:18083/api-docs/index.html) to view the API document and execute the management APIs from the Swagger UI. By default, under the Dashboard configuration, `swagger_support` is set to `true`, indicating Swagger UI support is enabled, which means all Swagger-related features are turned on, such as generating interactive API documentation. You can also set it to `false` to disable this feature. For more information, see [Dashboard configuration](../configuration/dashboard.md).
+EMQX provides multiple ways to explore and interact with the REST API. After EMQX is started, the following API specification endpoints are available:
 
-The section introduces how to work with EMQX REST API.
+| Endpoint | Format | Description |
+| --- | --- | --- |
+| `/api-spec.html` | HTML | Drill-down style API reference page for human reading. |
+| `/api-spec.md` | Markdown | API reference in Markdown format, suited for AI agents and automation tools. |
+| `/api-spec.json` | JSON | OpenAPI 3.0 specification in JSON format, suited for scripts and programmatic tooling. |
+| `/api-docs/index.html` | HTML | Interactive Swagger UI with "Try it" support for testing API calls directly in the browser. |
+
+All of the above endpoints require `swagger_support` to be set to `true` (the default) in the Dashboard configuration. Set it to `false` to disable all API documentation endpoints. For more information, see [Dashboard configuration](../configuration/dashboard.md).
+
+This section introduces how to work with the EMQX REST API.
 
 ## Basic Path
 

--- a/en_US/admin/api.md
+++ b/en_US/admin/api.md
@@ -9,7 +9,7 @@ EMQX provides multiple ways to explore and interact with the REST API. After EMQ
 | `/api-spec.html` | HTML | Drill-down style API reference page for human reading. |
 | `/api-spec.md` | Markdown | API reference in Markdown format, suited for AI agents and automation tools. |
 | `/api-spec.json` | JSON | OpenAPI 3.0 specification in JSON format, suited for scripts and programmatic tooling. |
-| `/api-docs/index.html` | HTML | Interactive Swagger UI with "Try it" support for testing API calls directly in the browser. |
+| `/api-docs/index.html` | HTML | Interactive Swagger UI with "Try it" support for testing API calls directly in the browser. **Deprecated**: will be removed in v7. |
 
 All of the above endpoints require `swagger_support` to be set to `true` (the default) in the Dashboard configuration. Set it to `false` to disable all API documentation endpoints. For more information, see [Dashboard configuration](../configuration/dashboard.md).
 

--- a/en_US/admin/cli.md
+++ b/en_US/admin/cli.md
@@ -1665,6 +1665,93 @@ $ emqx ctl admins del emqx_u
 ok
 ```
 
+## api_keys
+
+The `api_keys` command can be used to manage REST API keys from the command line. This is useful for bootstrapping API access without needing to log in to the Dashboard first.
+
+### api_keys list
+
+List all API keys.
+
+```bash
+$ emqx ctl api_keys list
+[
+  {
+    "role" : "administrator",
+    "name" : "my-key",
+    "expired_at" : "infinity",
+    "expired" : false,
+    "enable" : true,
+    "desc" : "",
+    "api_key" : "admin"
+  }
+]
+```
+
+### api_keys show --name \<Name\>
+
+Show details of a specific API key.
+
+```bash
+$ emqx ctl api_keys show --name my-key
+```
+
+### api_keys add
+
+Create a new API key. The generated `api_key` and `api_secret` are returned in the output. The `api_secret` is only shown once at creation time.
+
+```bash
+$ emqx ctl api_keys add --name my-key --role viewer --valid-days 30 --desc "My API key"
+{
+  "role" : "viewer",
+  "name" : "my-key",
+  "expired_at" : 1777201070,
+  "expired" : false,
+  "enable" : true,
+  "desc" : "My API key",
+  "api_secret" : "tEWX9APine9B9Bkk...",
+  "api_key" : "CPKcoFpIkIlbaqhL"
+}
+```
+
+Options:
+
+| Option | Description |
+| --- | --- |
+| `--name <Name>` | Required. A name to identify the API key. |
+| `--api-secret <Secret>` | Optional. Specify a secret key. If omitted, one is generated automatically. |
+| `--valid-days <infinity\|days>` | Optional. Validity period. Use `infinity` for no expiration (default), or a number of days. |
+| `--role <Role>` | Optional. One of `administrator` (default), `viewer`, or `publisher`. See [Roles and Permissions](./api.md#roles-and-permissions). |
+| `--desc <Desc>` | Optional. A description for the API key. |
+
+### api_keys enable --name \<Name\>
+
+Enable a previously disabled API key.
+
+```bash
+$ emqx ctl api_keys enable --name my-key
+```
+
+### api_keys disable --name \<Name\>
+
+Disable an API key without deleting it.
+
+```bash
+$ emqx ctl api_keys disable --name my-key
+```
+
+### api_keys del --name \<Name\>
+
+Delete an API key.
+
+```bash
+$ emqx ctl api_keys del --name my-key
+{
+  "result" : "ok",
+  "name" : "my-key"
+}
+```
+
 ## rules
 
 This command is used to list rules created in the Rule Engine.

--- a/en_US/configuration/dashboard.md
+++ b/en_US/configuration/dashboard.md
@@ -128,7 +128,7 @@ Where,
 
 - `swagger_support = true`
 
-  Enable Swagger (OpenAPI) UI available at the endpoint `/api-docs`. Set to `false` to disable.
+  Enable API documentation endpoints, including the Swagger UI (`/api-docs`) and the API spec pages (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`). Set to `false` to disable all API documentation endpoints.
 
 - `default_password`
 

--- a/en_US/configuration/dashboard.md
+++ b/en_US/configuration/dashboard.md
@@ -128,7 +128,7 @@ Where,
 
 - `swagger_support = true`
 
-  Enable API documentation endpoints, including the Swagger UI (`/api-docs`) and the API spec pages (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`). Set to `false` to disable all API documentation endpoints.
+  Enable API documentation endpoints, including the API spec pages (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`) and the Swagger UI (`/api-docs`, deprecated — will be removed in v7). Set to `false` to disable all API documentation endpoints.
 
 - `default_password`
 

--- a/en_US/configuration/dashboard.md
+++ b/en_US/configuration/dashboard.md
@@ -128,7 +128,7 @@ Where,
 
 - `swagger_support = true`
 
-  Enable API documentation endpoints, including the API spec pages (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`) and the Swagger UI (`/api-docs`, deprecated — will be removed in v7). Set to `false` to disable all API documentation endpoints.
+  Enable API documentation endpoints, including the API spec pages (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`) and the Swagger UI (`/api-docs`, deprecated and will be removed in v7). Set to `false` to disable all API documentation endpoints.
 
 - `default_password`
 

--- a/zh_CN/admin/api.md
+++ b/zh_CN/admin/api.md
@@ -2,7 +2,16 @@
 
 EMQX 提供了管理监控 REST API，这些 API 遵循 OpenAPI (Swagger) 3.0 规范。
 
-EMQX 服务启动后，您可以访问 [http://localhost:18083/api-docs/index.html](http://localhost:18083/api-docs/index.html) 来查看 API 的文档。还可以直接在 Swagger UI 上尝试执行一些 API。默认情况下，Dashboard 配置下的 `swagger_support` 设置为 `true`，表示启用 Swagger UI 支持，即开启所有 swagger 相关的功能，例如生成交互式 API 文档。您也可以将它设置为 `false` 以禁用此功能。
+EMQX 提供了多种方式来浏览和使用 REST API。EMQX 服务启动后，以下 API 规范端点可用：
+
+| 端点 | 格式 | 描述 |
+| --- | --- | --- |
+| `/api-spec.html` | HTML | 逐层展开式 API 参考页面，适合人工阅读。 |
+| `/api-spec.md` | Markdown | Markdown 格式的 API 参考，适合 AI 代理和自动化工具使用。 |
+| `/api-spec.json` | JSON | OpenAPI 3.0 规范的 JSON 格式，适合脚本和程序化工具使用。 |
+| `/api-docs/index.html` | HTML | 交互式 Swagger UI，支持在浏览器中直接测试 API 调用。 |
+
+以上所有端点均需要 Dashboard 配置中的 `swagger_support` 设置为 `true`（默认值）。将其设置为 `false` 可禁用所有 API 文档端点。更多信息请参阅 [Dashboard 配置](../configuration/dashboard.md)。
 
 本节将指导您快速开始使用 EMQX REST API。
 

--- a/zh_CN/admin/cli.md
+++ b/zh_CN/admin/cli.md
@@ -1659,6 +1659,93 @@ $ emqx ctl admins del emqx_u
 ok
 ```
 
+## api_keys
+
+`api_keys` 命令用于从命令行管理 REST API 密钥。这在无需登录 Dashboard 即可引导 API 访问时非常有用。
+
+### api_keys list
+
+列出所有 API 密钥。
+
+```bash
+$ emqx ctl api_keys list
+[
+  {
+    "role" : "administrator",
+    "name" : "my-key",
+    "expired_at" : "infinity",
+    "expired" : false,
+    "enable" : true,
+    "desc" : "",
+    "api_key" : "admin"
+  }
+]
+```
+
+### api_keys show --name \<Name\>
+
+查看指定 API 密钥的详细信息。
+
+```bash
+$ emqx ctl api_keys show --name my-key
+```
+
+### api_keys add
+
+创建新的 API 密钥。输出中将返回生成的 `api_key` 和 `api_secret`。`api_secret` 仅在创建时显示一次。
+
+```bash
+$ emqx ctl api_keys add --name my-key --role viewer --valid-days 30 --desc "My API key"
+{
+  "role" : "viewer",
+  "name" : "my-key",
+  "expired_at" : 1777201070,
+  "expired" : false,
+  "enable" : true,
+  "desc" : "My API key",
+  "api_secret" : "tEWX9APine9B9Bkk...",
+  "api_key" : "CPKcoFpIkIlbaqhL"
+}
+```
+
+选项：
+
+| 选项 | 描述 |
+| --- | --- |
+| `--name <Name>` | 必填。用于标识 API 密钥的名称。 |
+| `--api-secret <Secret>` | 可选。指定密钥。如果省略，将自动生成。 |
+| `--valid-days <infinity\|days>` | 可选。有效期。使用 `infinity` 表示永不过期（默认），或指定天数。 |
+| `--role <Role>` | 可选。`administrator`（默认）、`viewer` 或 `publisher` 之一。参见[角色与权限](./api.md#角色与权限)。 |
+| `--desc <Desc>` | 可选。API 密钥的描述信息。 |
+
+### api_keys enable --name \<Name\>
+
+启用之前被禁用的 API 密钥。
+
+```bash
+$ emqx ctl api_keys enable --name my-key
+```
+
+### api_keys disable --name \<Name\>
+
+禁用 API 密钥（不删除）。
+
+```bash
+$ emqx ctl api_keys disable --name my-key
+```
+
+### api_keys del --name \<Name\>
+
+删除 API 密钥。
+
+```bash
+$ emqx ctl api_keys del --name my-key
+{
+  "result" : "ok",
+  "name" : "my-key"
+}
+```
+
 ## rules
 
 查看系统中创建的所有的规则。

--- a/zh_CN/configuration/dashboard.md
+++ b/zh_CN/configuration/dashboard.md
@@ -127,7 +127,7 @@ dashboard {
 
 - `swagger_support = true`
 
-  用于启用所有与 swagger 相关的功能，如生成 Swagger API 文档。默认情况下，其值始终为 `true`，您可以将值设置为 `false` 以禁用它。
+  用于启用 API 文档端点，包括 Swagger UI（`/api-docs`）和 API 规范页面（`/api-spec.html`、`/api-spec.md`、`/api-spec.json`）。将其设置为 `false` 可禁用所有 API 文档端点。
 
 - `default_password`
 


### PR DESCRIPTION
## Summary

- Document new API specification endpoints (`/api-spec.html`, `/api-spec.md`, `/api-spec.json`) alongside the existing Swagger UI
- Add `api_keys` CLI command documentation (list, show, add, enable, disable, del)
- Update `swagger_support` config description to cover all API doc endpoints
- Both en_US and zh_CN translations included