### PR TITLE
chore(crl): add more details about crl caching (r61)

### DIFF
--- a/en_US/network/crl.md
+++ b/en_US/network/crl.md
@@ -1,12 +1,21 @@
 # CRL Check
 
-Since EMQX Enterprise v5.0.3, Certification Revocation List (CRL) Check is supported for MQTT SSL listeners. Note that those do not include Secure WebSocket nor QUIC listeners: only listeners of type `ssl` support this feature.
+Starting with EMQX v5.0.3, EMQX supports Certificate Revocation List (CRL) checks for MQTT SSL listeners. This feature is only available for listeners of type `ssl`. Secure WebSocket (`wss`) and QUIC listeners are not supported.
 
-With this feature enabled, EMQX will attempt to verify if connecting client certificates are not revoked according to the CRL Distribution Point described in the client's certificate, and deny connection to revoked client certificates during the SSL/TLS handshake phase of the connection.  Note that the CRL itself must contain the ["Issuing Distribution Point" extension](https://www.rfc-editor.org/rfc/rfc3280#section-5.2.5) in order for the revocation check to be enforced.
+When CRL checking is enabled, EMQX verifies whether a connecting client's certificate has been revoked by consulting the CRL Distribution Point specified in the client certificate. If the certificate is listed as revoked, the connection is rejected during the SSL/TLS handshake phase.
 
-In order to enable this feature, we need to both enable the corresponding option in the listener and also set the `verify` option of the listener to `verify_peer`, so that the client must be checked against the CRL.
+> **Note**
+>
+> For CRL enforcement to work, the CRL must include the *Issuing Distribution Point* extension, as defined in [RFC 3280, Section 5.2.5](https://www.rfc-editor.org/rfc/rfc3280#section-5.2.5).
 
-Example configuration to enable CRL Check:
+## Enable CRL Check
+
+To enable CRL checking, you must:
+
+1. Enable the CRL check option on the SSL listener.
+2. Set the listener's `verify` option to `verify_peer`, ensuring that client certificates are validated.
+
+The following example demonstrates how to configure an SSL listener with CRL checking enabled:
 
 
 ```hcl
@@ -28,3 +37,9 @@ listeners.ssl.default {
   }
 }
 ```
+
+## CRL Caching
+
+To avoid excessive HTTP requests to CRL Distribution Point endpoints, EMQX caches fetched CRLs locally.
+
+When a client connects, and EMQX detects a new CRL URL for the first time, it fetches the CRL from the Distribution Point in the client's certificate. By default, EMQX refreshes cached CRLs every 15 minutes to ensure revocation information remains up to date.

--- a/zh_CN/network/crl.md
+++ b/zh_CN/network/crl.md
@@ -1,38 +1,44 @@
 # CRL 检查
 
-从 EMQX 企业版 5.0.3 开始，EMQX 支持针对 MQTT SSL 监听器设置证书吊销列表（CRL）检查功能。
+从 EMQX v5.0.3 开始，EMQX 支持对 MQTT SSL 监听器进行证书吊销列表（Certificate Revocation List，CRL）检查。该功能仅适用于类型为 `ssl` 的监听器，不支持安全 WebSocket（`wss`）和 QUIC 监听器。
 
-注意：QUIC 类型监听器暂不支持此功能。
+启用 CRL 检查后，EMQX 会根据客户端证书中指定的 CRL 分发点（CRL Distribution Point）来验证客户端证书是否已被吊销。如果证书被标记为已吊销，EMQX 将在 SSL/TLS 握手阶段拒绝该连接。
 
-启用 CRL 检查后，EMQX 将根据客户端证书中的 CRD 信息对申请建立连接的客户端进行验证，如证书已被撤销，EMQX 将拒绝连接请求。
+> **注意**
+>
+> 要使 CRL 吊销检查生效，CRL 本身必须包含 *Issuing Distribution Point* 扩展，详见 [RFC 3280 第 5.2.5 节](https://www.rfc-editor.org/rfc/rfc3280#section-5.2.5)。
 
-注意：CRL 中应包含 ["Issuing Distribution Point " 扩展](https://www.rfc-editor.org/rfc/rfc3280#section-5.2.5)，以便执行 CRL 检查。
+## 启用 CRL 检查
 
-## 通过配置文件配置
+要启用 CRL 检查，需要同时满足以下条件：
 
-EMQX 支持通过配置文件 `emqx.conf` 启用 CRL 检查功能。
+1. 在 SSL 监听器中启用 CRL 检查选项。
+2. 将监听器的 `verify` 选项设置为 `verify_peer`，以确保对客户端证书进行校验。
 
-您只需将相关的配置项附加到 `emqx.conf` 文件的末尾，相应设置将在 EMQX 重启后生效。
-
-**示例代码**：
+以下示例展示了如何配置启用了 CRL 检查的 SSL 监听器：
 
 
 ```hcl
 listeners.ssl.default {
   bind = "0.0.0.0:8883"
-  max_connections = 512000
   ssl_options {
-    # PEM format file containing the trusted CA (certificate authority) certificates that the listener uses to verify the authenticity of the clients.
+    # 包含受信任 CA（证书颁发机构）证书的 PEM 格式文件，用于验证客户端证书的合法性
     cacertfile = "/etc/emqx/certs/ca.pem"
-    # PEM format file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
+
+    # 包含监听器 SSL/TLS 证书链的 PEM 格式文件。
+    # 如果证书不是由根 CA 直接签发，需要在监听器证书后附加中间 CA 证书以形成完整证书链
     certfile = "/etc/emqx/certs/server.pem"
-    # PEM format file containing the private key corresponding to the SSL/TLS certificate
+
+    # 与 SSL/TLS 证书对应的私钥 PEM 文件
     keyfile = "/etc/emqx/certs/server.key"
-    # Must verify peer certificates
+
+    # 必须校验客户端证书
     verify = verify_peer
-    # Force the client to send a non-empty certificate, otherwise fail the TLS handshake.
+
+    # 强制客户端发送非空证书，否则 TLS 握手失败
     fail_if_no_peer_cert = true
-    # Also verify client certificate's revocation status
+
+    # 启用客户端证书吊销状态（CRL）检查
     enable_crl_check = true
   }
 }
@@ -41,4 +47,10 @@ listeners.ssl.default {
 其中：
 
 - `verify = verify_peer` 表示将启用对端验证。
-- `enable_crl_check = true` 表示启用CRL 检查。
+- `enable_crl_check = true` 表示启用 CRL 检查。
+
+## CRL 缓存
+
+为了避免频繁向 CRL 分发点发起 HTTP 请求，EMQX 会在本地缓存已获取的 CRL。
+
+当客户端连接时，如果 EMQX 首次检测到新的 CRL URL，会从客户端证书中指定的分发点获取对应的 CRL。默认情况下，EMQX 每 15 分钟刷新一次缓存的 CRL，以确保证书吊销信息保持最新。


### PR DESCRIPTION
## Summary

- Port changes from PR #3360 to this branch
- Rewrites intro, fixes CRD typo in ZH, restructures config steps into numbered list
- Adds `## CRL Caching` / `## CRL 缓存` section explaining the 15-minute refresh interval
- Removes Open Source/Enterprise edition distinction (no longer applicable from v5.9+)

## Reason for manual port

PR #3360 was merged into `release-5.8` on 2026-02-09 but was never synced to later branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)