### PR TITLE
docs: add IPv6 configuration guide

### DIFF
--- a/dir.yaml
+++ b/dir.yaml
@@ -390,7 +390,7 @@
           title_ja: 国密 SSL
           lang: cn
           path: network/gmssl
-      # - network/ipv6
+      - network/ipv6
     - title_en: Authentication
       title_cn: 认证
       title_ja: 認証

--- a/dir.yaml
+++ b/dir.yaml
@@ -390,7 +390,7 @@
           title_ja: 国密 SSL
           lang: cn
           path: network/gmssl
-      - network/ipv6
+        - network/ipv6
     - title_en: Authentication
       title_cn: 认证
       title_ja: 認証

--- a/en_US/network/ipv6.md
+++ b/en_US/network/ipv6.md
@@ -66,11 +66,11 @@ listeners.wss.default {
 }
 ```
 
-## Dashboard Listener
+## Dashboard HTTP/HTTPS Listeners
 
 The EMQX Dashboard HTTP/HTTPS listener also supports IPv6.
 
-### Using an IPv6 Bind Address
+### Use an IPv6 Bind Address
 
 When the `bind` address is an IPv6 address, EMQX automatically enables IPv6 for the Dashboard listener:
 
@@ -80,7 +80,7 @@ dashboard.listeners.http {
 }
 ```
 
-### Using the `inet6` Flag
+### Use the `inet6` Flag
 
 Alternatively, if using a port-only bind (without an explicit IP address), you can enable IPv6 explicitly:
 
@@ -117,9 +117,9 @@ Available options:
 | `inet_tls`   | TLS over IPv4, configured via `etc/ssl_dist.conf`        |
 | `inet6_tls`  | TLS over IPv6, configured via `etc/ssl_dist.conf`        |
 
-::: warning
+::: warning Important Notice
 
-When using IPv6 node names (for example, `emqx@::1`), you **must** set `cluster.proto_dist` to `inet6_tcp` or `inet6_tls`. Otherwise the node will fail to start with errors such as "not responding to pings".
+When using IPv6 node names (for example, `emqx@::1`), you **must** set `cluster.proto_dist` to `inet6_tcp` or `inet6_tls`. Otherwise, the node will fail to start with errors such as "not responding to pings".
 
 :::
 
@@ -196,7 +196,7 @@ dashboard.listeners.http {
 
 **Cause**: The Erlang distribution protocol defaults to `inet_tcp` (IPv4). An IPv6 node name requires `inet6_tcp`.
 
-**Fix**: Set `cluster.proto_dist = inet6_tcp` in `emqx.conf`.
+**Solution**: Set `cluster.proto_dist = inet6_tcp` in `emqx.conf`.
 
 ### `enetunreach` Errors in Outbound Connections
 
@@ -204,7 +204,7 @@ dashboard.listeners.http {
 
 **Cause**: The connection is attempting to use IPv4 to reach an IPv6-only service, or vice versa.
 
-**Fix**: Verify that the target service is reachable from the EMQX host using the correct address family. For HTTP connectors, the automatic IPv6 probe should handle this. If the service is behind a DNS name, ensure the DNS returns the correct record type (A for IPv4, AAAA for IPv6).
+**Solution**: Verify that the target service is reachable from the EMQX host using the correct address family. For HTTP connectors, the automatic IPv6 probe should handle this. If the service is behind a DNS name, ensure the DNS returns the correct record type (A for IPv4, AAAA for IPv6).
 
 ### Dashboard Unreachable on IPv6
 
@@ -212,4 +212,4 @@ dashboard.listeners.http {
 
 **Cause**: The Dashboard listener defaults to IPv4 (`0.0.0.0:18083`).
 
-**Fix**: Either bind the Dashboard to an IPv6 address (`bind = "[::]:18083"`), or explicitly enable IPv6 with `inet6 = true`.
+**Solution**: Either bind the Dashboard to an IPv6 address (`bind = "[::]:18083"`), or explicitly enable IPv6 with `inet6 = true`.

--- a/en_US/network/ipv6.md
+++ b/en_US/network/ipv6.md
@@ -1,1 +1,215 @@
 # IPv6
+
+EMQX fully supports IPv6 for client connections, the Dashboard, inter-node clustering, and outbound connections to external services. This page explains how to configure EMQX for IPv6 environments, from single-stack (IPv6-only) to dual-stack deployments.
+
+## MQTT Listeners
+
+To accept MQTT client connections over IPv6, bind the listener to an IPv6 address. EMQX automatically enables the `inet6` socket option when it detects an IPv6 bind address.
+
+### Dual-Stack (IPv4 and IPv6)
+
+Bind to `[::]` to accept both IPv4 and IPv6 connections on the same port:
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+}
+```
+
+::: tip
+
+On most operating systems, binding to `[::]` accepts both IPv4 and IPv6 connections by default (dual-stack). This is the simplest configuration for environments that need to support both protocols.
+
+:::
+
+### IPv6-Only
+
+To restrict the listener to IPv6 connections only, set `ipv6_v6only = true`:
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+```
+
+This sets the `IPV6_V6ONLY` socket option, which prevents IPv4-mapped IPv6 addresses from being accepted.
+
+### Bind to a Specific IPv6 Address
+
+You can bind to a specific IPv6 address:
+
+```bash
+listeners.tcp.default {
+  bind = "[::1]:1883"
+}
+```
+
+The same configuration applies to SSL, WebSocket, and Secure WebSocket listeners:
+
+```bash
+listeners.ssl.default {
+  bind = "[::]:8883"
+  ssl_options {
+    certfile = "etc/certs/cert.pem"
+    keyfile = "etc/certs/key.pem"
+    cacertfile = "etc/certs/cacert.pem"
+  }
+}
+
+listeners.ws.default {
+  bind = "[::]:8083"
+}
+
+listeners.wss.default {
+  bind = "[::]:8084"
+}
+```
+
+## Dashboard Listener
+
+The EMQX Dashboard HTTP/HTTPS listener also supports IPv6.
+
+### Using an IPv6 Bind Address
+
+When the `bind` address is an IPv6 address, EMQX automatically enables IPv6 for the Dashboard listener:
+
+```bash
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+### Using the `inet6` Flag
+
+Alternatively, if using a port-only bind (without an explicit IP address), you can enable IPv6 explicitly:
+
+```bash
+dashboard.listeners.http {
+  bind = 18083
+  inet6 = true
+}
+```
+
+| Parameter    | Type    | Default | Description                                                                 |
+| ------------ | ------- | ------- | --------------------------------------------------------------------------- |
+| `inet6`      | boolean | `false` | Enable IPv6 support. When `false`, the listener accepts only IPv4 traffic.  |
+| `ipv6_v6only`| boolean | `false` | Disable IPv4-to-IPv6 mapping. Only effective when `inet6` is `true`.        |
+
+## Cluster Communication
+
+When nodes in an EMQX cluster communicate over an IPv6 network, two components need configuration: the Erlang distribution protocol (used for cluster coordination) and the Gen RPC channel (used for data forwarding between nodes).
+
+### Erlang Distribution Protocol
+
+Set `cluster.proto_dist` to use IPv6 for inter-node communication:
+
+```bash
+cluster.proto_dist = inet6_tcp
+```
+
+Available options:
+
+| Value        | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `inet_tcp`   | TCP over IPv4 (default)                                  |
+| `inet6_tcp`  | TCP over IPv6                                            |
+| `inet_tls`   | TLS over IPv4, configured via `etc/ssl_dist.conf`        |
+| `inet6_tls`  | TLS over IPv6, configured via `etc/ssl_dist.conf`        |
+
+::: warning
+
+When using IPv6 node names (for example, `emqx@::1`), you **must** set `cluster.proto_dist` to `inet6_tcp` or `inet6_tls`. Otherwise the node will fail to start with errors such as "not responding to pings".
+
+:::
+
+### Gen RPC
+
+Configure the Gen RPC channel for IPv6:
+
+```bash
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+```
+
+| Parameter           | Type    | Default     | Description                                                                                  |
+| ------------------- | ------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `rpc.listen_address`| string  | `0.0.0.0`   | IP address for the RPC server. Use `0.0.0.0` for IPv4 or `::` for IPv6.                     |
+| `rpc.ipv6_only`     | boolean | `false`     | When `listen_address` is IPv6, setting this to `true` forces the RPC client to use IPv6 only. |
+
+## Outbound Connections
+
+EMQX makes outbound connections to external services for features such as HTTP authentication, webhook actions, and database integrations.
+
+### Automatic IPv6 Detection
+
+For HTTP-based connectors (authentication backends, webhook actions, etc.), EMQX automatically probes whether the target host supports IPv6 and selects the appropriate address family. No manual configuration is required in most cases.
+
+### Manual Override
+
+Some connector types expose an `ipv6_probe` toggle in their configuration. When enabled (the default for HTTP connectors), EMQX attempts an IPv6 connection first. If your network is IPv4-only and DNS returns both A and AAAA records, you can disable the probe to avoid connection delays:
+
+```bash
+# Example: HTTP authentication backend
+authentication {
+  backend = "http"
+  method = "post"
+  url = "http://auth-server.example.com:8080/auth"
+
+  # Disable IPv6 auto-detection if not needed
+  pool_size = 8
+}
+```
+
+## Complete IPv6-Only Example
+
+Below is a minimal `emqx.conf` for an IPv6-only deployment:
+
+```bash
+# Node name using IPv6 address
+node.name = "emqx@::1"
+
+# Cluster distribution over IPv6
+cluster.proto_dist = inet6_tcp
+
+# Gen RPC over IPv6
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+
+# MQTT listener on IPv6
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+
+# Dashboard on IPv6
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+## Troubleshooting
+
+### Node Not Responding to Pings
+
+**Symptom**: When starting a cluster node with an IPv6 node name, the node reports "not responding to pings" and fails to start.
+
+**Cause**: The Erlang distribution protocol defaults to `inet_tcp` (IPv4). An IPv6 node name requires `inet6_tcp`.
+
+**Fix**: Set `cluster.proto_dist = inet6_tcp` in `emqx.conf`.
+
+### `enetunreach` Errors in Outbound Connections
+
+**Symptom**: Outbound HTTP requests (e.g., to authentication backends) fail with `enetunreach` (network unreachable).
+
+**Cause**: The connection is attempting to use IPv4 to reach an IPv6-only service, or vice versa.
+
+**Fix**: Verify that the target service is reachable from the EMQX host using the correct address family. For HTTP connectors, the automatic IPv6 probe should handle this. If the service is behind a DNS name, ensure the DNS returns the correct record type (A for IPv4, AAAA for IPv6).
+
+### Dashboard Unreachable on IPv6
+
+**Symptom**: The Dashboard is not accessible when EMQX is running in an IPv6-only environment.
+
+**Cause**: The Dashboard listener defaults to IPv4 (`0.0.0.0:18083`).
+
+**Fix**: Either bind the Dashboard to an IPv6 address (`bind = "[::]:18083"`), or explicitly enable IPv6 with `inet6 = true`.

--- a/en_US/network/overview.md
+++ b/en_US/network/overview.md
@@ -50,3 +50,7 @@ authentication {
 ## TLS for Nodes Communication
 
 Instructions on how to enable SSL/TLS for cluster connections are not covered in this chapter, and you can refer to [Cluster Security](../deploy/cluster/security.md) for details.
+
+## IPv6 Support
+
+EMQX fully supports IPv6 for client connections, the Dashboard, inter-node cluster communication, and outbound connections to external services. For configuration details, see [IPv6](./ipv6.md).

--- a/ja_JP/network/ipv6.md
+++ b/ja_JP/network/ipv6.md
@@ -1,0 +1,215 @@
+# IPv6
+
+EMQX fully supports IPv6 for client connections, the Dashboard, inter-node clustering, and outbound connections to external services. This page explains how to configure EMQX for IPv6 environments, from single-stack (IPv6-only) to dual-stack deployments.
+
+## MQTT Listeners
+
+To accept MQTT client connections over IPv6, bind the listener to an IPv6 address. EMQX automatically enables the `inet6` socket option when it detects an IPv6 bind address.
+
+### Dual-Stack (IPv4 and IPv6)
+
+Bind to `[::]` to accept both IPv4 and IPv6 connections on the same port:
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+}
+```
+
+::: tip
+
+On most operating systems, binding to `[::]` accepts both IPv4 and IPv6 connections by default (dual-stack). This is the simplest configuration for environments that need to support both protocols.
+
+:::
+
+### IPv6-Only
+
+To restrict the listener to IPv6 connections only, set `ipv6_v6only = true`:
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+```
+
+This sets the `IPV6_V6ONLY` socket option, which prevents IPv4-mapped IPv6 addresses from being accepted.
+
+### Bind to a Specific IPv6 Address
+
+You can bind to a specific IPv6 address:
+
+```bash
+listeners.tcp.default {
+  bind = "[::1]:1883"
+}
+```
+
+The same configuration applies to SSL, WebSocket, and Secure WebSocket listeners:
+
+```bash
+listeners.ssl.default {
+  bind = "[::]:8883"
+  ssl_options {
+    certfile = "etc/certs/cert.pem"
+    keyfile = "etc/certs/key.pem"
+    cacertfile = "etc/certs/cacert.pem"
+  }
+}
+
+listeners.ws.default {
+  bind = "[::]:8083"
+}
+
+listeners.wss.default {
+  bind = "[::]:8084"
+}
+```
+
+## Dashboard HTTP/HTTPS Listeners
+
+The EMQX Dashboard HTTP/HTTPS listener also supports IPv6.
+
+### Use an IPv6 Bind Address
+
+When the `bind` address is an IPv6 address, EMQX automatically enables IPv6 for the Dashboard listener:
+
+```bash
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+### Use the `inet6` Flag
+
+Alternatively, if using a port-only bind (without an explicit IP address), you can enable IPv6 explicitly:
+
+```bash
+dashboard.listeners.http {
+  bind = 18083
+  inet6 = true
+}
+```
+
+| Parameter    | Type    | Default | Description                                                                 |
+| ------------ | ------- | ------- | --------------------------------------------------------------------------- |
+| `inet6`      | boolean | `false` | Enable IPv6 support. When `false`, the listener accepts only IPv4 traffic.  |
+| `ipv6_v6only`| boolean | `false` | Disable IPv4-to-IPv6 mapping. Only effective when `inet6` is `true`.        |
+
+## Cluster Communication
+
+When nodes in an EMQX cluster communicate over an IPv6 network, two components need configuration: the Erlang distribution protocol (used for cluster coordination) and the Gen RPC channel (used for data forwarding between nodes).
+
+### Erlang Distribution Protocol
+
+Set `cluster.proto_dist` to use IPv6 for inter-node communication:
+
+```bash
+cluster.proto_dist = inet6_tcp
+```
+
+Available options:
+
+| Value        | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `inet_tcp`   | TCP over IPv4 (default)                                  |
+| `inet6_tcp`  | TCP over IPv6                                            |
+| `inet_tls`   | TLS over IPv4, configured via `etc/ssl_dist.conf`        |
+| `inet6_tls`  | TLS over IPv6, configured via `etc/ssl_dist.conf`        |
+
+::: warning Important Notice
+
+When using IPv6 node names (for example, `emqx@::1`), you **must** set `cluster.proto_dist` to `inet6_tcp` or `inet6_tls`. Otherwise, the node will fail to start with errors such as "not responding to pings".
+
+:::
+
+### Gen RPC
+
+Configure the Gen RPC channel for IPv6:
+
+```bash
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+```
+
+| Parameter           | Type    | Default     | Description                                                                                  |
+| ------------------- | ------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `rpc.listen_address`| string  | `0.0.0.0`   | IP address for the RPC server. Use `0.0.0.0` for IPv4 or `::` for IPv6.                     |
+| `rpc.ipv6_only`     | boolean | `false`     | When `listen_address` is IPv6, setting this to `true` forces the RPC client to use IPv6 only. |
+
+## Outbound Connections
+
+EMQX makes outbound connections to external services for features such as HTTP authentication, webhook actions, and database integrations.
+
+### Automatic IPv6 Detection
+
+For HTTP-based connectors (authentication backends, webhook actions, etc.), EMQX automatically probes whether the target host supports IPv6 and selects the appropriate address family. No manual configuration is required in most cases.
+
+### Manual Override
+
+Some connector types expose an `ipv6_probe` toggle in their configuration. When enabled (the default for HTTP connectors), EMQX attempts an IPv6 connection first. If your network is IPv4-only and DNS returns both A and AAAA records, you can disable the probe to avoid connection delays:
+
+```bash
+# Example: HTTP authentication backend
+authentication {
+  backend = "http"
+  method = "post"
+  url = "http://auth-server.example.com:8080/auth"
+
+  # Disable IPv6 auto-detection if not needed
+  pool_size = 8
+}
+```
+
+## Complete IPv6-Only Example
+
+Below is a minimal `emqx.conf` for an IPv6-only deployment:
+
+```bash
+# Node name using IPv6 address
+node.name = "emqx@::1"
+
+# Cluster distribution over IPv6
+cluster.proto_dist = inet6_tcp
+
+# Gen RPC over IPv6
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+
+# MQTT listener on IPv6
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+
+# Dashboard on IPv6
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+## Troubleshooting
+
+### Node Not Responding to Pings
+
+**Symptom**: When starting a cluster node with an IPv6 node name, the node reports "not responding to pings" and fails to start.
+
+**Cause**: The Erlang distribution protocol defaults to `inet_tcp` (IPv4). An IPv6 node name requires `inet6_tcp`.
+
+**Solution**: Set `cluster.proto_dist = inet6_tcp` in `emqx.conf`.
+
+### `enetunreach` Errors in Outbound Connections
+
+**Symptom**: Outbound HTTP requests (e.g., to authentication backends) fail with `enetunreach` (network unreachable).
+
+**Cause**: The connection is attempting to use IPv4 to reach an IPv6-only service, or vice versa.
+
+**Solution**: Verify that the target service is reachable from the EMQX host using the correct address family. For HTTP connectors, the automatic IPv6 probe should handle this. If the service is behind a DNS name, ensure the DNS returns the correct record type (A for IPv4, AAAA for IPv6).
+
+### Dashboard Unreachable on IPv6
+
+**Symptom**: The Dashboard is not accessible when EMQX is running in an IPv6-only environment.
+
+**Cause**: The Dashboard listener defaults to IPv4 (`0.0.0.0:18083`).
+
+**Solution**: Either bind the Dashboard to an IPv6 address (`bind = "[::]:18083"`), or explicitly enable IPv6 with `inet6 = true`.

--- a/zh_CN/network/ipv6.md
+++ b/zh_CN/network/ipv6.md
@@ -1,1 +1,215 @@
 # IPv6
+
+EMQX 全面支持 IPv6，涵盖客户端连接、Dashboard、集群节点间通信以及到外部服务的出站连接。本页介绍如何在 IPv6 环境中配置 EMQX，包括纯 IPv6（单栈）和双栈部署。
+
+## MQTT 监听器
+
+要通过 IPv6 接受 MQTT 客户端连接，需将监听器绑定到 IPv6 地址。当检测到 IPv6 绑定地址时，EMQX 会自动启用 `inet6` 套接字选项。
+
+### 双栈（IPv4 和 IPv6）
+
+绑定到 `[::]` 可在同一端口上同时接受 IPv4 和 IPv6 连接：
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+}
+```
+
+::: tip
+
+在大多数操作系统上，绑定到 `[::]` 默认同时接受 IPv4 和 IPv6 连接（双栈模式）。这是需要同时支持两种协议的环境中最简单的配置方式。
+
+:::
+
+### 仅 IPv6
+
+要将监听器限制为仅接受 IPv6 连接，请设置 `ipv6_v6only = true`：
+
+```bash
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+```
+
+此选项设置 `IPV6_V6ONLY` 套接字选项，阻止接受 IPv4 映射的 IPv6 地址。
+
+### 绑定到特定 IPv6 地址
+
+可以绑定到特定的 IPv6 地址：
+
+```bash
+listeners.tcp.default {
+  bind = "[::1]:1883"
+}
+```
+
+相同的配置方式适用于 SSL、WebSocket 和安全 WebSocket 监听器：
+
+```bash
+listeners.ssl.default {
+  bind = "[::]:8883"
+  ssl_options {
+    certfile = "etc/certs/cert.pem"
+    keyfile = "etc/certs/key.pem"
+    cacertfile = "etc/certs/cacert.pem"
+  }
+}
+
+listeners.ws.default {
+  bind = "[::]:8083"
+}
+
+listeners.wss.default {
+  bind = "[::]:8084"
+}
+```
+
+## Dashboard 监听器
+
+EMQX Dashboard 的 HTTP/HTTPS 监听器同样支持 IPv6。
+
+### 使用 IPv6 绑定地址
+
+当 `bind` 地址为 IPv6 地址时，EMQX 会自动为 Dashboard 监听器启用 IPv6：
+
+```bash
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+### 使用 `inet6` 标志
+
+如果仅使用端口号绑定（不指定 IP 地址），可以显式启用 IPv6：
+
+```bash
+dashboard.listeners.http {
+  bind = 18083
+  inet6 = true
+}
+```
+
+| 参数          | 类型    | 默认值  | 说明                                                                   |
+| ------------ | ------- | ------- | ---------------------------------------------------------------------- |
+| `inet6`      | boolean | `false` | 启用 IPv6 支持。设为 `false` 时，监听器仅接受 IPv4 流量。                   |
+| `ipv6_v6only`| boolean | `false` | 禁用 IPv4 到 IPv6 的地址映射。仅在 `inet6` 为 `true` 时生效。              |
+
+## 集群通信
+
+当 EMQX 集群中的节点通过 IPv6 网络通信时，需要配置两个组件：Erlang 分布式协议（用于集群协调）和 Gen RPC 通道（用于节点间数据转发）。
+
+### Erlang 分布式协议
+
+设置 `cluster.proto_dist` 以使用 IPv6 进行节点间通信：
+
+```bash
+cluster.proto_dist = inet6_tcp
+```
+
+可用选项：
+
+| 值            | 说明                                             |
+| ------------ | ------------------------------------------------ |
+| `inet_tcp`   | 基于 IPv4 的 TCP（默认）                            |
+| `inet6_tcp`  | 基于 IPv6 的 TCP                                   |
+| `inet_tls`   | 基于 IPv4 的 TLS，通过 `etc/ssl_dist.conf` 配置      |
+| `inet6_tls`  | 基于 IPv6 的 TLS，通过 `etc/ssl_dist.conf` 配置      |
+
+::: warning
+
+当使用 IPv6 节点名称（例如 `emqx@::1`）时，**必须**将 `cluster.proto_dist` 设置为 `inet6_tcp` 或 `inet6_tls`。否则节点将无法启动，并报告"not responding to pings"错误。
+
+:::
+
+### Gen RPC
+
+为 Gen RPC 配置 IPv6：
+
+```bash
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+```
+
+| 参数                 | 类型    | 默认值      | 说明                                                                         |
+| ------------------- | ------- | ----------- | --------------------------------------------------------------------------- |
+| `rpc.listen_address`| string  | `0.0.0.0`   | RPC 服务器监听的 IP 地址。IPv4 使用 `0.0.0.0`，IPv6 使用 `::`。                  |
+| `rpc.ipv6_only`     | boolean | `false`     | 当 `listen_address` 为 IPv6 地址时，设为 `true` 可强制 RPC 客户端仅使用 IPv6。     |
+
+## 出站连接
+
+EMQX 会向外部服务发起出站连接，用于 HTTP 认证、Webhook 动作、数据库集成等功能。
+
+### 自动 IPv6 检测
+
+对于基于 HTTP 的连接器（认证后端、Webhook 动作等），EMQX 会自动探测目标主机是否支持 IPv6，并选择合适的地址族。大多数情况下无需手动配置。
+
+### 手动配置
+
+部分连接器类型在其配置中提供了 `ipv6_probe` 开关。启用时（HTTP 连接器默认启用），EMQX 会优先尝试 IPv6 连接。如果您的网络仅支持 IPv4 且 DNS 同时返回 A 和 AAAA 记录，可以禁用此探测以避免连接延迟：
+
+```bash
+# 示例：HTTP 认证后端
+authentication {
+  backend = "http"
+  method = "post"
+  url = "http://auth-server.example.com:8080/auth"
+
+  # 如不需要，可禁用 IPv6 自动检测
+  pool_size = 8
+}
+```
+
+## 完整的纯 IPv6 配置示例
+
+以下是纯 IPv6 部署的最小化 `emqx.conf` 配置：
+
+```bash
+# 使用 IPv6 地址的节点名称
+node.name = "emqx@::1"
+
+# 集群分布式协议使用 IPv6
+cluster.proto_dist = inet6_tcp
+
+# Gen RPC 使用 IPv6
+rpc.listen_address = "::"
+rpc.ipv6_only = true
+
+# MQTT 监听器使用 IPv6
+listeners.tcp.default {
+  bind = "[::]:1883"
+  ipv6_v6only = true
+}
+
+# Dashboard 使用 IPv6
+dashboard.listeners.http {
+  bind = "[::]:18083"
+}
+```
+
+## 故障排查
+
+### 节点无法响应 Ping
+
+**现象**：使用 IPv6 节点名称启动集群节点时，节点报告"not responding to pings"并无法启动。
+
+**原因**：Erlang 分布式协议默认使用 `inet_tcp`（IPv4）。IPv6 节点名称需要使用 `inet6_tcp`。
+
+**解决方法**：在 `emqx.conf` 中设置 `cluster.proto_dist = inet6_tcp`。
+
+### 出站连接报 `enetunreach` 错误
+
+**现象**：出站 HTTP 请求（例如到认证后端的请求）失败，错误为 `enetunreach`（网络不可达）。
+
+**原因**：连接尝试使用 IPv4 访问仅支持 IPv6 的服务，或反之。
+
+**解决方法**：验证目标服务可通过正确的地址族从 EMQX 主机访问。对于 HTTP 连接器，自动 IPv6 探测功能通常可以处理此问题。如果服务使用域名，请确保 DNS 返回正确的记录类型（IPv4 为 A 记录，IPv6 为 AAAA 记录）。
+
+### IPv6 环境下 Dashboard 无法访问
+
+**现象**：在纯 IPv6 环境中运行 EMQX 时，无法访问 Dashboard。
+
+**原因**：Dashboard 监听器默认使用 IPv4（`0.0.0.0:18083`）。
+
+**解决方法**：将 Dashboard 绑定到 IPv6 地址（`bind = "[::]:18083"`），或显式启用 IPv6（`inet6 = true`）。

--- a/zh_CN/network/ipv6.md
+++ b/zh_CN/network/ipv6.md
@@ -4,7 +4,7 @@ EMQX 全面支持 IPv6，涵盖客户端连接、Dashboard、集群节点间通�
 
 ## MQTT 监听器
 
-要通过 IPv6 接受 MQTT 客户端连接，需将监听器绑定到 IPv6 地址。当检测到 IPv6 绑定地址时，EMQX 会自动启用 `inet6` 套接字选项。
+要通过 IPv6 接受 MQTT 客户端连接，需将监听器绑定到 IPv6 地址。当检测到 IPv6 绑定地址时，EMQX 会自动启用 `inet6` socket 选项。
 
 ### 双栈（IPv4 和 IPv6）
 
@@ -33,7 +33,7 @@ listeners.tcp.default {
 }
 ```
 
-此选项设置 `IPV6_V6ONLY` 套接字选项，阻止接受 IPv4 映射的 IPv6 地址。
+此选项设置 `IPV6_V6ONLY` socket 选项，阻止接受 IPv4 映射的 IPv6 地址。
 
 ### 绑定到特定 IPv6 地址
 
@@ -66,7 +66,7 @@ listeners.wss.default {
 }
 ```
 
-## Dashboard 监听器
+## Dashboard HTTP/HTTPS 监听器
 
 EMQX Dashboard 的 HTTP/HTTPS 监听器同样支持 IPv6。
 
@@ -117,7 +117,7 @@ cluster.proto_dist = inet6_tcp
 | `inet_tls`   | 基于 IPv4 的 TLS，通过 `etc/ssl_dist.conf` 配置      |
 | `inet6_tls`  | 基于 IPv6 的 TLS，通过 `etc/ssl_dist.conf` 配置      |
 
-::: warning
+::: warning 重要提示
 
 当使用 IPv6 节点名称（例如 `emqx@::1`）时，**必须**将 `cluster.proto_dist` 设置为 `inet6_tcp` 或 `inet6_tls`。否则节点将无法启动，并报告"not responding to pings"错误。
 
@@ -196,7 +196,7 @@ dashboard.listeners.http {
 
 **原因**：Erlang 分布式协议默认使用 `inet_tcp`（IPv4）。IPv6 节点名称需要使用 `inet6_tcp`。
 
-**解决方法**：在 `emqx.conf` 中设置 `cluster.proto_dist = inet6_tcp`。
+**解决方案**：在 `emqx.conf` 中设置 `cluster.proto_dist = inet6_tcp`。
 
 ### 出站连接报 `enetunreach` 错误
 
@@ -204,7 +204,7 @@ dashboard.listeners.http {
 
 **原因**：连接尝试使用 IPv4 访问仅支持 IPv6 的服务，或反之。
 
-**解决方法**：验证目标服务可通过正确的地址族从 EMQX 主机访问。对于 HTTP 连接器，自动 IPv6 探测功能通常可以处理此问题。如果服务使用域名，请确保 DNS 返回正确的记录类型（IPv4 为 A 记录，IPv6 为 AAAA 记录）。
+**解决方案**：验证目标服务可通过正确的地址族从 EMQX 主机访问。对于 HTTP 连接器，自动 IPv6 探测功能通常可以处理此问题。如果服务使用域名，请确保 DNS 返回正确的记录类型（IPv4 为 A 记录，IPv6 为 AAAA 记录）。
 
 ### IPv6 环境下 Dashboard 无法访问
 
@@ -212,4 +212,4 @@ dashboard.listeners.http {
 
 **原因**：Dashboard 监听器默认使用 IPv4（`0.0.0.0:18083`）。
 
-**解决方法**：将 Dashboard 绑定到 IPv6 地址（`bind = "[::]:18083"`），或显式启用 IPv6（`inet6 = true`）。
+**解决方案**：将 Dashboard 绑定到 IPv6 地址（`bind = "[::]:18083"`），或显式启用 IPv6（`inet6 = true`）。

--- a/zh_CN/network/overview.md
+++ b/zh_CN/network/overview.md
@@ -60,3 +60,7 @@ authentication {
 ## 启用 TLS 加密节点通信
 
 关于如何在集群节点通信中启用 TLS的具体介绍，您可以参阅[集群安全](../deploy/cluster/security.md)。
+
+## IPv6 支持
+
+EMQX 全面支持 IPv6，涵盖客户端连接、Dashboard、集群节点间通信以及到外部服务的出站连接。详细配置说明请参阅 [IPv6](./ipv6.md)。


### PR DESCRIPTION
## Summary

Add a comprehensive IPv6 documentation page at `network/ipv6.md` (was a stub with just `# IPv6`).

Covers:
- MQTT listener IPv6 binding (dual-stack, IPv6-only, specific address)
- Dashboard listener IPv6 (auto-infer from bind address, explicit `inet6` flag)
- Cluster communication (`cluster.proto_dist`, Gen RPC)
- Outbound connections (automatic IPv6 probe)
- Complete IPv6-only deployment example
- Troubleshooting common IPv6 issues

Also uncomments the `network/ipv6` entry in `dir.yaml` to include the page in navigation.

Includes both English (`en_US`) and Chinese (`zh_CN`) translations.