### PR TITLE
docs(hooks): add client.post_authn hook point

### DIFF
--- a/en_US/extensions/hooks.md
+++ b/en_US/extensions/hooks.md
@@ -109,6 +109,7 @@ EMQX is based on a client's key activities during its life cycle and presets a l
 | client.connected     | Connection succeed          | After client authentication is completed and successfully connected to the system           |
 | client.disconnected  | Disconnect                  | Connection layer of client is ready to close                                                |
 | client.authenticate  | Connection authentication   | After `client.connect` is executed                                                          |
+| client.post_authn    | Post-authentication rewrite | After the authentication chain in `client.authenticate` completes (added in 6.1.2)          |
 | client.authorize     | Pub/Sub authorization       | Before `publish/subscribe` operation is executed                                            |
 | client.subscribe     | Subscribe to topic          | After receiving the subscription message, and before executing `client.authorize`           |
 | client.unsubscribe   | Unsubscribe                 | After receiving the unsubscribe packet                                                      |
@@ -166,6 +167,7 @@ For parameter data structure, see [emqx_types.erl](https://github.com/emqx/emqx/
 | client.connected     | `ClientInfo`: Client information parameters<br />`ConnInfo`: Client connection layer parameters | -                  |
 | client.disconnected  | `ClientInfo`: Client information parameters<br />`ConnInfo`: Client connection layer parameters<br />`ReasonCode`: Reason code | -                  |
 | client.authenticate  | `ClientInfo`: Client information parameters<br />`AuthNResult`: Authentication results | New `AuthNResult`  |
+| client.post_authn    | `ClientInfo`: Merged client information (includes authentication-response `client_attrs`) | New `ClientInfo`, or `{error, Reason}` to reject (added in 6.1.2) |
 | client.authorize     | `ClientInfo`: Client information parameters<br />`Topic`: Publish/subscribe topic<br />`PubSub`: Publish/subscribe<br />`AuthZResult`: Authentication result | New `AuthZResult`  |
 | client.subscribe     | `ClientInfo`: Client information parameters<br />`Props`: Properties parameters of MQTT v5.0 subscription messages<br />`TopicFilters`: List of topics of subscription | New `TopicFilters` |
 | client.unsubscribe   | `ClientInfo`: Client information parameters<br />`Props`: Properties parameters of MQTT v5.0 unsubscription messages<br />`TopicFilters`: List of topics of unsubscription | New `TopicFilters` |

--- a/en_US/extensions/hooks.md
+++ b/en_US/extensions/hooks.md
@@ -167,7 +167,7 @@ For parameter data structure, see [emqx_types.erl](https://github.com/emqx/emqx/
 | client.connected     | `ClientInfo`: Client information parameters<br />`ConnInfo`: Client connection layer parameters | -                  |
 | client.disconnected  | `ClientInfo`: Client information parameters<br />`ConnInfo`: Client connection layer parameters<br />`ReasonCode`: Reason code | -                  |
 | client.authenticate  | `ClientInfo`: Client information parameters<br />`AuthNResult`: Authentication results | New `AuthNResult`  |
-| client.post_authn    | `ClientInfo`: Merged client information (includes authentication-response `client_attrs`) | New `ClientInfo`, or `{error, Reason}` to reject (added in 6.1.2) |
+| client.post_authn    | `Context`: Map `#{client_info := ClientInfo}` with the merged client information (includes authentication-response `client_attrs`) | New `Context`, or `{error, Reason}` to reject (added in 6.1.2) |
 | client.authorize     | `ClientInfo`: Client information parameters<br />`Topic`: Publish/subscribe topic<br />`PubSub`: Publish/subscribe<br />`AuthZResult`: Authentication result | New `AuthZResult`  |
 | client.subscribe     | `ClientInfo`: Client information parameters<br />`Props`: Properties parameters of MQTT v5.0 subscription messages<br />`TopicFilters`: List of topics of subscription | New `TopicFilters` |
 | client.unsubscribe   | `ClientInfo`: Client information parameters<br />`Props`: Properties parameters of MQTT v5.0 unsubscription messages<br />`TopicFilters`: List of topics of unsubscription | New `TopicFilters` |

--- a/ja_JP/extensions/hooks.md
+++ b/ja_JP/extensions/hooks.md
@@ -163,7 +163,7 @@ emqx:unhook(Name, {Module, Function}).
 | client.connected      | `ClientInfo`：クライアント情報パラメータ<br />`ConnInfo`：クライアント接続層パラメータ            | -                   |
 | client.disconnected   | `ClientInfo`：クライアント情報パラメータ<br />`ConnInfo`：クライアント接続層パラメータ<br />`ReasonCode`：理由コード | -                   |
 | client.authenticate   | `ClientInfo`：クライアント情報パラメータ<br />`AuthNResult`：認証結果                             | 新しい `AuthNResult` |
-| client.post_authn     | `ClientInfo`：マージされたクライアント情報（認証応答の `client_attrs` を含む）                       | 新しい `ClientInfo`、または `{error, Reason}` で接続を拒否（6.1.2 で追加） |
+| client.post_authn     | `Context`：コンテキスト map `#{client_info := ClientInfo}`。マージされたクライアント情報（認証応答の `client_attrs` を含む）を保持 | 新しい `Context`、または `{error, Reason}` で接続を拒否（6.1.2 で追加） |
 | client.authorize      | `ClientInfo`：クライアント情報パラメータ<br />`Topic`：パブリッシュ／サブスクライブトピック<br />`PubSub`：パブリッシュ／サブスクライブ区分<br />`AuthZResult`：認可結果 | 新しい `AuthZResult` |
 | client.subscribe      | `ClientInfo`：クライアント情報パラメータ<br />`Props`：MQTT v5.0 サブスクライブメッセージのプロパティ<br />`TopicFilters`：サブスクライブトピックのリスト | 新しい `TopicFilters` |
 | client.unsubscribe    | `ClientInfo`：クライアント情報パラメータ<br />`Props`：MQTT v5.0 サブスクライブ解除メッセージのプロパティ<br />`TopicFilters`：サブスクライブ解除トピックのリスト | 新しい `TopicFilters` |

--- a/ja_JP/extensions/hooks.md
+++ b/ja_JP/extensions/hooks.md
@@ -106,6 +106,7 @@ EMQX はクライアントのライフサイクルにおける主要なアクテ
 | client.connected      | 接続成功                     | クライアント認証が完了し、システムへの接続が成功した後                                       |
 | client.disconnected   | 切断                         | クライアントの接続層が閉じる準備ができたとき                                                 |
 | client.authenticate   | 接続認証                     | `client.connect` 実行後                                                                       |
+| client.post_authn     | 認証後のクライアント情報書換 | `client.authenticate` の認証チェーン完了後（6.1.2 で追加）                                    |
 | client.authorize      | Pub/Sub 認可                 | `publish/subscribe` 操作実行前                                                                |
 | client.subscribe      | トピックのサブスクライブ       | サブスクライブメッセージ受信後、`client.authorize` 実行前                                    |
 | client.unsubscribe    | サブスクライブ解除             | サブスクライブ解除パケット受信後                                                               |
@@ -162,6 +163,7 @@ emqx:unhook(Name, {Module, Function}).
 | client.connected      | `ClientInfo`：クライアント情報パラメータ<br />`ConnInfo`：クライアント接続層パラメータ            | -                   |
 | client.disconnected   | `ClientInfo`：クライアント情報パラメータ<br />`ConnInfo`：クライアント接続層パラメータ<br />`ReasonCode`：理由コード | -                   |
 | client.authenticate   | `ClientInfo`：クライアント情報パラメータ<br />`AuthNResult`：認証結果                             | 新しい `AuthNResult` |
+| client.post_authn     | `ClientInfo`：マージされたクライアント情報（認証応答の `client_attrs` を含む）                       | 新しい `ClientInfo`、または `{error, Reason}` で接続を拒否（6.1.2 で追加） |
 | client.authorize      | `ClientInfo`：クライアント情報パラメータ<br />`Topic`：パブリッシュ／サブスクライブトピック<br />`PubSub`：パブリッシュ／サブスクライブ区分<br />`AuthZResult`：認可結果 | 新しい `AuthZResult` |
 | client.subscribe      | `ClientInfo`：クライアント情報パラメータ<br />`Props`：MQTT v5.0 サブスクライブメッセージのプロパティ<br />`TopicFilters`：サブスクライブトピックのリスト | 新しい `TopicFilters` |
 | client.unsubscribe    | `ClientInfo`：クライアント情報パラメータ<br />`Props`：MQTT v5.0 サブスクライブ解除メッセージのプロパティ<br />`TopicFilters`：サブスクライブ解除トピックのリスト | 新しい `TopicFilters` |

--- a/zh_CN/extensions/hooks.md
+++ b/zh_CN/extensions/hooks.md
@@ -124,6 +124,7 @@ EMQX 以一个客户端在其生命周期内事件为基础，预置了大量的
 | client.connected     | 成功接入     | 客户端认证完成并成功接入系统后                        |
 | client.disconnected  | 连接断开     | 客户端连接层在准备关闭时                              |
 | client.authenticate  | 连接认证     | 执行完 `client.connect` 后                            |
+| client.post_authn    | 认证后改写   | `client.authenticate` 认证链执行完成后（6.1.2 新增）  |
 | client.authorize     | 发布订阅鉴权 | 执行 `发布/订阅` 操作前                               |
 | client.subscribe     | 订阅主题     | 收到订阅报文后，执行 `client.authorize` 鉴权前        |
 | client.unsubscribe   | 取消订阅     | 收到取消订阅报文后                                    |
@@ -182,6 +183,7 @@ emqx:unhook(Name, {Module, Function}).
 | client.connected     | `ClientInfo`：客户端信息参数<br />`ConnInfo`： 客户端连接层参数                                                               | -                   |
 | client.disconnected  | `ClientInfo`：客户端信息参数<br />`ConnInfo`：客户端连接层参数<br />`ReasonCode`：错误码                                      | -                   |
 | client.authenticate  | `ClientInfo`：客户端信息参数<br />`AuthNResult`：认证结果                                                                     | 新的 `AuthNResult`  |
+| client.post_authn    | `ClientInfo`：合并后的客户端信息（包含认证响应的 `client_attrs`）                                                                 | 新的 `ClientInfo`，或返回 `{error, Reason}` 拒绝连接（6.1.2 新增） |
 | client.authorize     | `ClientInfo`：客户端信息参数<br />`Topic`：发布/订阅的主题<br />`PubSub`：发布或订阅<br />`AuthZResult`：授权结果             | 新的 `AuthZResult`  |
 | client.subscribe     | `ClientInfo`：客户端信息参数<br />`Props`：MQTT v5.0 订阅报文的 Properties 参数<br />`TopicFilters`：需订阅的主题列表         | 新的 `TopicFilters` |
 | client.unsubscribe   | `ClientInfo`：客户端信息参数<br />`Props`：MQTT v5.0 取消订阅报文的 Properties 参数<br />`TopicFilters`：需取消订阅的主题列表 | 新的 `TopicFilters` |

--- a/zh_CN/extensions/hooks.md
+++ b/zh_CN/extensions/hooks.md
@@ -183,7 +183,7 @@ emqx:unhook(Name, {Module, Function}).
 | client.connected     | `ClientInfo`：客户端信息参数<br />`ConnInfo`： 客户端连接层参数                                                               | -                   |
 | client.disconnected  | `ClientInfo`：客户端信息参数<br />`ConnInfo`：客户端连接层参数<br />`ReasonCode`：错误码                                      | -                   |
 | client.authenticate  | `ClientInfo`：客户端信息参数<br />`AuthNResult`：认证结果                                                                     | 新的 `AuthNResult`  |
-| client.post_authn    | `ClientInfo`：合并后的客户端信息（包含认证响应的 `client_attrs`）                                                                 | 新的 `ClientInfo`，或返回 `{error, Reason}` 拒绝连接（6.1.2 新增） |
+| client.post_authn    | `Context`：上下文 map `#{client_info := ClientInfo}`，包含合并后的客户端信息（含认证响应的 `client_attrs`）                          | 新的 `Context`，或返回 `{error, Reason}` 拒绝连接（6.1.2 新增） |
 | client.authorize     | `ClientInfo`：客户端信息参数<br />`Topic`：发布/订阅的主题<br />`PubSub`：发布或订阅<br />`AuthZResult`：授权结果             | 新的 `AuthZResult`  |
 | client.subscribe     | `ClientInfo`：客户端信息参数<br />`Props`：MQTT v5.0 订阅报文的 Properties 参数<br />`TopicFilters`：需订阅的主题列表         | 新的 `TopicFilters` |
 | client.unsubscribe   | `ClientInfo`：客户端信息参数<br />`Props`：MQTT v5.0 取消订阅报文的 Properties 参数<br />`TopicFilters`：需取消订阅的主题列表 | 新的 `TopicFilters` |


### PR DESCRIPTION
Document the new `client.post_authn` hook point introduced in EMQX 6.1.2.

The callback is invoked after the authentication chain in `client.authenticate` completes and receives the merged `ClientInfo` (including `client_attrs` rewritten by the authn response). Handlers can return a new `ClientInfo` to replace the accumulator, or `{error, Reason}` to reject the client.

Updates the HookPoint List and Callback Function tables in en_US, zh_CN, and ja_JP.