### PR TITLE
Fix 4.4 MySQL rule doc config

### DIFF
--- a/zh_CN/rule/backend_mysql.md
+++ b/zh_CN/rule/backend_mysql.md
@@ -84,9 +84,9 @@ insert into t_mqtt_msg(msgid, topic, qos, payload, arrived) values (${id}, ${top
 
 填写资源配置:
 
-数据库名填写 “mqtt”，用户名填写 “root”，密码填写 “123456”
+数据库名填写 “test”，用户名填写 “root”，密码填写 “public”
 
-![image](./assets/rule-engine/rule_action_3@2x.png)
+![image](./assets/rule-engine/rule_resource_1@2x.png)
 
 点击 “新建” 按钮。
 


### PR DESCRIPTION
Fix: https://emqx.atlassian.net/browse/EEC-1318


## Summary

- Align the Chinese MySQL rule engine resource configuration with the database created earlier in the document.
- Replace the outdated resource screenshot reference with the existing screenshot that shows `test` / `root` / `public`.

## Root Cause

The Chinese v4.4 `backend_mysql` page created and used the `test` database with root password `public`, but the later resource configuration text and screenshot still referenced `mqtt` and `123456`.
