### PR TITLE
docs(authn): restructure x509 cert field mapping security warning [backport to 5.8]

### DIFF
--- a/en_US/access-control/authn/x509.md
+++ b/en_US/access-control/authn/x509.md
@@ -41,23 +41,19 @@ EMQX supports mapping X.509 certificate information as a username or client ID t
 
 ::: warning mTLS Required for Certificate Field Mapping
 
-If you set `peer_cert_as_username` or `peer_cert_as_clientid` to anything other than `disabled`, the SSL listener **must** enforce mutual TLS:
+If you set `peer_cert_as_username` or `peer_cert_as_clientid` to anything other than `disabled`, the SSL listener must enforce mutual TLS:
 
 - `verify = verify_peer`
 - `fail_if_no_peer_cert = true`
 - `cacertfile` set to a CA bundle you control (do not trust public CAs that can issue certificates for arbitrary names)
 
-Without mTLS, a client can connect without presenting a certificate at all, or present a self-signed certificate with any CN/DN it chooses — EMQX will not validate it.
-EMQX then maps the empty or attacker-chosen CN/DN directly to the username or client ID.
-An empty username can become a security corner case for downstream external authenticators (e.g. HTTP authenticator), and an attacker-chosen CN/DN lets the client impersonate any other identity.
-With mTLS enforced, EMQX rejects the handshake before the mapping is applied.
+:::
 
-As an additional layer for the empty-username case, set `listeners.{type}.{name}.enable_authn = quick_deny_anonymous` so that any client whose derived username is empty is rejected immediately without entering the authentication chain. This complements mTLS — it does not protect against a forged CN/DN, only mTLS does.
+Without mTLS, a client can connect without presenting a certificate, or present a self-signed certificate with any CN/DN it chooses. EMQX does not validate it and maps the CN/DN directly to the username or client ID. An attacker-chosen CN/DN allows the client to impersonate any identity. An empty CN/DN can also cause unexpected behavior in downstream authenticators such as the HTTP authenticator. With mTLS enforced, EMQX rejects the handshake before the mapping is applied.
 
-**The same risk applies with PROXY protocol v2.** If you terminate TLS at an upstream load balancer (LB), enable `proxy_protocol = true` on a TCP listener, and trust the CN/DN the LB injects:
+::: tip Note
 
-- The LB must itself perform mTLS and only forward the verified CN/DN.
-- The listener must only be reachable from the trusted LB. Enforce this in EMQX with `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]`, and combine with network-level controls (firewall / private network / Unix socket) as defense in depth. Any attacker who can reach the PROXY-protocol port directly can craft a PROXY v2 frame with arbitrary cert TLVs and impersonate any client.
+As an additional safeguard for the empty-username case, set `listeners.{type}.{name}.enable_authn = quick_deny_anonymous` so that any client whose derived username is empty is rejected immediately without entering the authentication chain. This complements mTLS but does not replace it: it does not protect against a forged CN/DN.
 
 :::
 
@@ -68,6 +64,15 @@ You can use fields from the peer certificate (such as CN, DN, or the entire cert
 - `crt`: DER format content of the certificate
 - `pem`: DER certificate converted to PEM format content
 - `md5`: MD5 value of the DER or PEM certificate content
+
+### PROXY Protocol Considerations
+
+If you terminate TLS at an upstream load balancer and enable `proxy_protocol = true` on a TCP listener, the same identity-spoofing risk applies: EMQX trusts the CN/DN the load balancer injects via the PROXY v2 frame. To use cert field mapping safely in this setup:
+
+- The load balancer must itself perform mTLS and forward only the verified CN/DN.
+- The PROXY-protocol listener must be reachable only from the trusted load balancer. Use `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]` and combine with network-level controls (firewall, private network, or Unix socket) as defense in depth.
+
+An attacker who can reach the PROXY-protocol port directly can craft a PROXY v2 frame with arbitrary cert fields and impersonate any client.
 
 ### Configure via Dashboard
 

--- a/zh_CN/access-control/authn/x509.md
+++ b/zh_CN/access-control/authn/x509.md
@@ -44,23 +44,19 @@ EMQX 支持将 X.509 证书信息映射为用户名或客户端 ID，以实现�
 
 ::: warning 映射对端证书字段时必须启用 mTLS
 
-如果将 `peer_cert_as_username` 或 `peer_cert_as_clientid` 设置为非 `disabled` 的取值，对应的 SSL 监听器**必须**强制启用双向 TLS：
+如果将 `peer_cert_as_username` 或 `peer_cert_as_clientid` 设置为非 `disabled` 的取值，对应的 SSL 监听器必须强制启用双向 TLS：
 
 - `verify = verify_peer`
 - `fail_if_no_peer_cert = true`
 - `cacertfile` 指向您自己掌控的 CA 证书集合（不要信任公共 CA，因为它们可以为任意名称签发证书）
 
-如果未启用 mTLS，客户端可以在完全不出示证书的情况下完成连接，也可以出示一张 CN/DN 任意填写的自签名证书 —— EMQX 不会对其做校验。
-EMQX 随后会将这个空值或被攻击者自选的 CN/DN 直接映射为用户名或客户端 ID。
-空用户名在下游外部认证器（例如 HTTP 认证器）中可能成为安全死角；而攻击者自选的 CN/DN 则可以让客户端冒充任意其他身份。
-启用 mTLS 后，EMQX 会在映射之前直接拒绝握手。
+:::
 
-针对空用户名场景，可在监听器上同时设置 `listeners.{type}.{name}.enable_authn = quick_deny_anonymous`，这样当客户端的派生用户名为空时会被立即拒绝，不进入认证链。该设置是对 mTLS 的补充 —— 它无法防御伪造 CN/DN 的攻击，那只能依靠 mTLS。
+如果未启用 mTLS，客户端可以在完全不出示证书的情况下完成连接，也可以出示一张 CN/DN 任意填写的自签名证书。EMQX 不会对其做校验，会直接将该 CN/DN 映射为用户名或客户端 ID。攻击者自选的 CN/DN 可以让客户端冒充任意身份；空的 CN/DN 则可能导致下游认证器（例如 HTTP 认证器）出现非预期行为。启用 mTLS 后，EMQX 会在映射之前直接拒绝握手。
 
-**通过 PROXY 协议 v2 转发证书信息时同样适用。** 如果在 TCP 监听器上启用了 `proxy_protocol = true`，并在上游负载均衡器终止 TLS 后信任其注入的 CN/DN：
+::: tip
 
-- 负载均衡器自身必须执行 mTLS，并且只转发已验证的 CN/DN。
-- 该监听器必须只能从受信任的负载均衡器访问到。在 EMQX 中通过 `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]` 进行限制，并结合网络层控制（防火墙 / 私有网络 / Unix socket）作为纵深防御。任何能直接访问 PROXY 协议端口的攻击者，都可以伪造一个带任意证书 TLV 的 PROXY v2 帧，从而冒充任意客户端。
+针对空用户名场景，可在监听器上同时设置 `listeners.{type}.{name}.enable_authn = quick_deny_anonymous`，这样当客户端的派生用户名为空时会被立即拒绝，不进入认证链。该设置是对 mTLS 的补充，但不能替代 mTLS，它无法防御伪造 CN/DN 的攻击。
 
 :::
 
@@ -71,6 +67,15 @@ EMQX 随后会将这个空值或被攻击者自选的 CN/DN 直接映射为用�
 - `crt`: 证书的 DER 格式内容
 - `pem`: DER 证书转换为 PEM 格式的内容
 - `md5`: 取 DER 或 PEM 证书内容的 MD5 值
+
+### PROXY 协议注意事项
+
+如果在上游负载均衡器终止 TLS，并在 TCP 监听器上启用了 `proxy_protocol = true`，同样存在身份伪造风险：EMQX 会信任负载均衡器通过 PROXY v2 帧注入的 CN/DN。在此场景下安全使用证书字段映射，需满足以下条件：
+
+- 负载均衡器自身必须执行 mTLS，并且只转发已验证的 CN/DN。
+- 该监听器必须只能从受信任的负载均衡器访问。在 EMQX 中通过 `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]` 进行限制，并结合网络层控制（防火墙、私有网络或 Unix socket）作为纵深防御。
+
+任何能直接访问 PROXY 协议端口的攻击者，都可以伪造一个带任意证书字段的 PROXY v2 帧，从而冒充任意客户端。
 
 ### 通过 Dashboard 设置
 


### PR DESCRIPTION
## Summary

Backport of the x509.md security warning restructure from PR #3519 (sync release-5.8 → release-5.9).

- Splits the monolithic `:::warning` block into three distinct parts: a tight checklist warning (mTLS requirements only), a body-text explanation of the threat model, and a `:::tip` for `quick_deny_anonymous`
- Moves the PROXY protocol risk into its own `### PROXY Protocol Considerations` subsection so it only surfaces for users in that topology
- Removes em dashes and tightens prose in the explanation paragraph
- Applies to both `en_US` and `zh_CN`

No content was removed; this is a restructure for scannability. The `security-checklist.md` files are already identical between 5.8 and this PR — no changes needed there.

## Test plan

- [ ] Verify rendered output in VitePress preview
- [ ] Confirm `:::warning`, `:::tip`, and `###` subsection render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)