### PR TITLE
docs(observability): add Broker Health Indicators reference

### DIFF
--- a/dir.yaml
+++ b/dir.yaml
@@ -836,6 +836,7 @@
         - observability/tracer
         - observability/mqtt-system-topics
         - observability/prometheus
+        - observability/broker-health-indicators
         - observability/datadog
         - title_en: Integrate with OpenTelemetry
           title_cn: 集成 OpenTelemetry

--- a/dir.yaml
+++ b/dir.yaml
@@ -836,7 +836,14 @@
         - observability/tracer
         - observability/mqtt-system-topics
         - observability/prometheus
-        - observability/broker-health-indicators
+        - title_en: Broker Health Indicators
+          title_cn: Broker 健康指标
+          path: observability/broker-health-indicators
+          lang: en
+        - title_en: Broker Health Indicators
+          title_cn: Broker 健康指标
+          path: observability/broker-health-indicators
+          lang: cn
         - observability/datadog
         - title_en: Integrate with OpenTelemetry
           title_cn: 集成 OpenTelemetry

--- a/en_US/observability/broker-health-indicators.md
+++ b/en_US/observability/broker-health-indicators.md
@@ -1,0 +1,316 @@
+# Broker Health Indicators
+
+This page is a curated reference of the most useful Prometheus metrics for monitoring an EMQX broker. Use it together with [Integrate with Prometheus](./prometheus.md), which covers how to expose and scrape these series.
+
+The indicators are organized into four areas:
+
+1. **System** — operating system and Erlang VM resources.
+2. **Broker** — connection and message traffic, plus broker state.
+3. **Authentication and authorization** — connect-time identity checks and per-message ACL decisions.
+4. **Data integration** — rules, actions, connectors, and bridges.
+
+All metrics are exposed on the EMQX Prometheus endpoints (`/api/v5/prometheus/stats`, `/api/v5/prometheus/auth`, and `/api/v5/prometheus/data_integration`). For endpoint details and `mode` query parameters, see [Integrate with Prometheus](./prometheus.md#configure-pull-mode-integration).
+
+::: tip Note on collector defaults
+
+The metrics prefixed `emqx_` are always on. The richer Erlang VM metrics prefixed `erlang_vm_` come from the upstream Prometheus Erlang exporter and are **disabled by default** in EMQX 6.0 and newer. Turn them on by setting `prometheus.collectors.vm_system_info = enabled` and similar for `vm_memory` and `vm_statistics` if you want process counts, per-allocator memory, or GC / scheduler breakdowns.
+
+:::
+
+## System
+
+The closest-to-the-iron signals. If the broker is unhealthy, one of these usually moves first.
+
+### CPU
+
+- `emqx_vm_cpu_use` — percent CPU used.
+- `emqx_vm_cpu_idle` — percent CPU idle.
+
+### Memory
+
+- `emqx_vm_total_memory` — total system memory (bytes).
+- `emqx_vm_used_memory` — used system memory (bytes).
+- `erlang_vm_memory_processes`, `erlang_vm_memory_atom`, `erlang_vm_memory_binary`, `erlang_vm_memory_ets`, `erlang_vm_memory_code`, `erlang_vm_memory_system` — per-allocator memory breakdown (requires the `vm_memory` collector enabled).
+
+### File descriptors
+
+- `emqx_vm_max_fds` — soft FD ulimit for the broker process.
+
+### Erlang processes and scheduler load
+
+- `emqx_vm_run_queue` — current scheduler run queue length. A sustained non-zero value indicates CPU saturation.
+- `emqx_vm_process_messages_in_queues` — sum of all Erlang process mailbox lengths. Large or growing values mean a process is unable to keep up with incoming work.
+- `erlang_vm_process_count` — current Erlang process count (requires the `vm_system_info` collector enabled).
+- `erlang_vm_process_limit` — configured maximum Erlang processes.
+
+### Internal mailbox watchdogs
+
+- `emqx_vm_mnesia_tm_mailbox_size` — Mnesia transaction manager mailbox depth; high values indicate transactional contention.
+- `emqx_vm_broker_pool_max_mailbox_size` — largest mailbox in the broker dispatch pool; high values indicate subscriber-side backpressure.
+
+### Uptime
+
+- `emqx_vm_uptime_ms` — broker uptime in milliseconds. A sudden drop to a small value means the node restarted.
+
+### Cluster replication health (Mria)
+
+- `emqx_mria_lag` — replication lag per replicant node.
+- `emqx_mria_replicants` — replicant count.
+- `emqx_mria_bootstrap_time` — time required for the last bootstrap.
+- `emqx_mria_message_queue_len` — Mria mailbox length.
+
+### Overload protection
+
+- `emqx_overload_protection_new_conn` — connections refused due to overload.
+- `emqx_overload_protection_gc` — forced garbage collections triggered by overload protection.
+- `emqx_overload_protection_hibernation` — process hibernations triggered.
+- `emqx_overload_protection_delay_ok` — successful delay applications.
+- `emqx_overload_protection_delay_timeout` — delay attempts that timed out.
+
+## Broker
+
+Headline operational signals. Watch the rate of message-related counters, and pay particular attention to the `dropped` series.
+
+### Cluster topology
+
+- `emqx_cluster_nodes_running` — running cluster nodes.
+- `emqx_cluster_nodes_stopped` — stopped cluster nodes. Alert when this is greater than zero.
+- `emqx_conf_sync_txid` — last cluster configuration transaction ID applied. Diverging values across nodes indicate a sync issue.
+
+### License (Enterprise)
+
+- `emqx_license_expiry_at` — license expiration time (UNIX epoch seconds).
+- `emqx_license_issued_at` — license issuance time.
+- `emqx_license_max_sessions` — license session cap.
+- `emqx_cert_expiry_at` — listener certificate expiration time.
+
+### Connections, sessions, and channels
+
+- `emqx_connections_count` — current connection count.
+- `emqx_connections_max` — peak connection count since boot.
+- `emqx_live_connections_count` — currently connected (TCP up) clients.
+- `emqx_live_connections_max` — peak live connections.
+- `emqx_sessions_count` — active session count (includes persistent sessions whose client is currently disconnected).
+- `emqx_sessions_max` — peak session count.
+- `emqx_cluster_sessions_count` — cluster-wide session count.
+- `emqx_cluster_sessions_max` — peak cluster-wide session count.
+- `emqx_channels_count` — channel processes (one per connected client).
+- `emqx_channels_max` — peak channel count.
+
+### Subscriptions and topics
+
+- `emqx_subscriptions_count` — subscription count.
+- `emqx_subscriptions_max` — peak subscriptions.
+- `emqx_subscriptions_shared_count` — shared subscriptions.
+- `emqx_subscriptions_shared_max` — peak shared subscriptions.
+- `emqx_subscribers_count` — subscriber processes.
+- `emqx_topics_count` — distinct topic count.
+- `emqx_topics_max` — peak topics.
+- `emqx_routes_count` — route table size.
+- `emqx_routes_max` — peak route table size.
+- `emqx_durable_subscriptions_count` — persistent-session subscriptions.
+- `emqx_durable_subscriptions_max` — peak persistent-session subscriptions.
+
+### Retained, delayed, and banned
+
+- `emqx_retained_count` — retained message count.
+- `emqx_retained_max` — peak retained count.
+- `emqx_delayed_count` — delayed-publish queue depth.
+- `emqx_delayed_max` — peak delayed queue depth.
+- `emqx_banned_count` — banned client / username / IP entries.
+
+### Messages
+
+- `emqx_messages_received` — application-level messages received from clients.
+- `emqx_messages_sent` — application-level messages sent to clients.
+- `emqx_messages_publish` — PUBLISH packets dispatched.
+- `emqx_messages_delivered` — deliveries to subscribers (one published message can produce multiple deliveries).
+- `emqx_messages_acked` — acknowledgements received from subscribers.
+- `emqx_messages_forward` — cross-node message forwards.
+- `emqx_messages_retained` — retained-message events.
+- `emqx_messages_delayed` — delayed-publish enqueues.
+
+### Message drops (the earliest sign of trouble)
+
+- `emqx_messages_dropped` — total dropped messages.
+- `emqx_messages_dropped_expired` — dropped because the message-expiry interval was exceeded.
+- `emqx_messages_dropped_no_subscribers` — dropped because no subscriber matched.
+- `emqx_messages_dropped_quota_exceeded` — dropped because a per-client quota was hit.
+- `emqx_messages_dropped_receive_maximum` — dropped because the subscriber's MQTT v5 receive-maximum quota was hit.
+
+### Per-subscriber delivery drops
+
+- `emqx_delivery_dropped` — total deliveries dropped.
+- `emqx_delivery_dropped_expired` — expired before delivery.
+- `emqx_delivery_dropped_no_local` — MQTT v5 no-local rule.
+- `emqx_delivery_dropped_qos` — QoS-not-supported.
+- `emqx_delivery_dropped_queue_full` — subscriber mqueue full.
+- `emqx_delivery_dropped_too_large` — exceeds subscriber's max packet size.
+
+### Bytes
+
+- `emqx_bytes_received` — total bytes received.
+- `emqx_bytes_sent` — total bytes sent.
+
+### Packet-level (for protocol-debug dashboards)
+
+- `emqx_packets_received` / `emqx_packets_sent` — total packets.
+- `emqx_packets_connect` — CONNECT packets received.
+- `emqx_packets_connack_sent` — CONNACK packets sent.
+- `emqx_packets_connack_error` — CONNACK with a non-zero reason code (most per-client AUTHN failures show here).
+- `emqx_packets_disconnect_received` / `emqx_packets_disconnect_sent` — DISCONNECT in / out.
+- `emqx_packets_publish_received` / `emqx_packets_publish_sent` — PUBLISH in / out.
+- `emqx_packets_publish_error` — PUBLISH that could not be accepted.
+- `emqx_packets_publish_auth_error` — PUBLISH denied by authorization.
+- `emqx_packets_puback_*`, `emqx_packets_pubrec_*`, `emqx_packets_pubrel_*`, `emqx_packets_pubcomp_*` — QoS 1 / 2 acknowledgement counters.
+- `emqx_packets_subscribe_received` / `emqx_packets_suback_sent` / `emqx_packets_subscribe_error` / `emqx_packets_subscribe_auth_error` — SUBSCRIBE accept / fail / AUTHZ-denied.
+- `emqx_packets_unsubscribe_received` / `emqx_packets_unsuback_sent` / `emqx_packets_unsubscribe_error`.
+- `emqx_packets_pingreq_received` / `emqx_packets_pingresp_sent` — keepalive activity.
+
+### Client lifecycle (hook trigger counters)
+
+- `emqx_client_connect` — CONNECT received.
+- `emqx_client_connack` — CONNACK sent.
+- `emqx_client_connected` — `client.connected` hook fired.
+- `emqx_client_disconnected` — `client.disconnected` hook fired.
+- `emqx_client_disconnected_reason` — disconnect counts labeled by reason.
+- `emqx_client_subscribe` / `emqx_client_unsubscribe` — subscribe hook fires.
+
+### Session lifecycle
+
+- `emqx_session_created` — sessions created.
+- `emqx_session_resumed` — persistent sessions resumed.
+- `emqx_session_takenover` — sessions taken over by a new client.
+- `emqx_session_discarded` — sessions discarded (clean start over an existing session).
+- `emqx_session_terminated` — sessions terminated.
+
+## Authentication and Authorization
+
+Useful when an HTTP, LDAP, or database backend is in the auth path and you need to see whether the broker or the backend is the slow or failing party.
+
+### Connect-time authentication outcomes
+
+- `emqx_authentication_success` — successful authentication (excluding anonymous).
+- `emqx_authentication_success_anonymous` — anonymous pass.
+- `emqx_authentication_failure` — authentication failures.
+
+### Authorization decisions
+
+- `emqx_authorization_allow` — decisions = allow.
+- `emqx_authorization_deny` — decisions = deny.
+- `emqx_authorization_nomatch` — no matching rule (falls back to the `no_match` configuration).
+- `emqx_authorization_matched_allow` — matched-allow rule fired.
+- `emqx_authorization_matched_deny` — matched-deny rule fired.
+- `emqx_authorization_cache_hit` — cache hits.
+- `emqx_authorization_cache_miss` — cache misses.
+- `emqx_authorization_superuser` — superuser-bypass path.
+
+### Authentication chain status
+
+- `emqx_authn_total` — configured authentication providers.
+- `emqx_authn_enable` — enabled flag per provider (0 / 1).
+- `emqx_authn_status` — resource state per provider.
+- `emqx_authn_users_count` — user record count per provider (for password, mnesia, or DB-backed providers).
+
+### Authentication per-provider runtime counters
+
+- `emqx_authn_success` — successful matches per provider.
+- `emqx_authn_failed` — failures per provider.
+- `emqx_authn_nomatch` — ignored (chain continues to the next provider).
+- `emqx_authn_latency` — backend latency per provider.
+
+### Authorization source status
+
+- `emqx_authz_total` — configured authorization sources.
+- `emqx_authz_enable` — enabled flag per source (0 / 1).
+- `emqx_authz_status` — resource state per source.
+- `emqx_authz_rules_count` — rule record count per source (file, mnesia, or DB-backed).
+
+### Authorization per-source runtime counters
+
+- `emqx_authz_allow` — decisions = allow per source.
+- `emqx_authz_deny` — decisions = deny per source.
+- `emqx_authz_nomatch` — ignored per source (chain continues).
+- `emqx_authz_latency` — backend latency per source.
+
+### Built-in DB sizes
+
+- `emqx_authn_builtin_record_count` — user count in the built-in authentication database.
+- `emqx_authz_builtin_record_count` — rule count in the built-in authorization database.
+
+## Data Integration
+
+The pipeline view: traffic enters the rule engine, fans out to connectors and actions, and lands at external systems. Each layer exposes its own counters; reading them in order shows where flow is being lost.
+
+### Inventory
+
+- `emqx_rules_count` — configured rules.
+- `emqx_actions_count` — configured actions.
+- `emqx_connectors_count` — configured connectors.
+- `emqx_schema_registrys_count` — schema-registry entries.
+
+### Per-resource status
+
+- `emqx_rule_enable` — rule enable flag (0 / 1).
+- `emqx_action_enable` — action enable flag (0 / 1).
+- `emqx_action_status` — action resource state.
+- `emqx_connector_enable` — connector enable flag (0 / 1).
+- `emqx_connector_status` — connector resource state.
+
+### Rule engine — per-rule counters
+
+- `emqx_rule_matched` — messages that matched the rule's WHERE clause.
+- `emqx_rule_passed` — messages that passed the rule.
+- `emqx_rule_failed` — rule processing failed.
+- `emqx_rule_failed_exception` — Erlang exception during the rule.
+- `emqx_rule_failed_no_result` — SQL produced no result.
+
+### Rule engine — action sub-counters
+
+- `emqx_rule_actions_total` — action invocations from rules.
+- `emqx_rule_actions_success` — action returned success.
+- `emqx_rule_actions_failed` — action failed.
+- `emqx_rule_actions_failed_unknown` — failure with unknown reason.
+- `emqx_rule_actions_failed_out_of_service` — downstream resource unhealthy.
+- `emqx_rule_actions_discarded` — action discarded (for example, rate limited).
+
+### Action throughput
+
+- `emqx_action_matched` — messages routed to the action.
+- `emqx_action_received` — received at the action queue.
+- `emqx_action_success` — action call succeeded.
+- `emqx_action_failed` — action call failed.
+- `emqx_action_late_reply` — response arrived after timeout.
+- `emqx_action_retried` — retry attempts.
+- `emqx_action_retried_success` — succeeded after retry.
+- `emqx_action_retried_failed` — failed after all retries.
+
+### Action queue and inflight
+
+- `emqx_action_inflight` — in-flight requests.
+- `emqx_action_queuing` — queued (pending dispatch) length.
+
+### Action drops
+
+A non-zero rate on any of these series is a strong signal that a downstream system is unhealthy or that the action's configuration is wrong.
+
+- `emqx_action_dropped` — total dropped at the action layer.
+- `emqx_action_dropped_queue_full` — queue cap hit.
+- `emqx_action_dropped_resource_stopped` — target resource stopped.
+- `emqx_action_dropped_resource_not_found` — target resource missing.
+- `emqx_action_dropped_expired` — message expired before dispatch.
+- `emqx_action_dropped_other` — other reasons.
+
+## Minimal "Broker-is-Sick" Panel
+
+If only a handful of series can fit on a single page, these are the load-bearing ones. Most production issues move at least one of them within seconds of the event:
+
+- `rate(emqx_messages_dropped[1m])` — non-zero means the broker is refusing or losing work.
+- `rate(emqx_action_dropped[1m])` — the integration layer is losing work.
+- `emqx_cluster_nodes_stopped` — greater than zero means a member was lost.
+- `rate(emqx_overload_protection_new_conn[1m])` — the broker is actively rejecting new connections.
+- `rate(emqx_authentication_failure[1m])` — an authentication failure spike usually indicates a backend issue or an attack.
+- `emqx_vm_run_queue` — sustained above zero means CPU saturation.
+- `emqx_vm_process_messages_in_queues` — large values indicate process-mailbox backlog.
+- `emqx_mria_lag` — values above a few seconds mean replication is falling behind.
+- `emqx_license_expiry_at - time()` (Enterprise) — countdown to license expiration.

--- a/en_US/observability/overview.md
+++ b/en_US/observability/overview.md
@@ -22,6 +22,10 @@ EMQX provides a series of observability-related features to help with system mon
 
   [Prometheus](https://prometheus.io/) is the monitoring solution open-sourced by SoundCloud, featuring its support for multidimensional data models, flexible query language, and powerful alarm management. EMQX supports integrating with Prometheus to collect system metrics and pushing metrics to `pushgateway`.
 
+- [Broker Health Indicators](./broker-health-indicators.md)
+
+  A curated reference of the most useful Prometheus metrics for monitoring an EMQX broker, organized by system, broker, authentication / authorization, and data integration. Use it together with the Prometheus integration guide to decide what to scrape, alert on, and chart.
+
 - [Integrate with Datadog](./datadog.md)
 
   [Datadog](https://www.datadoghq.com/) is an observability platform that provides unified, real-time observability and security solutions for applications. EMQX supports the integration of Datadog to help you understand the EMQX operating status, monitor and troubleshoot system performance issues, and view EMQX metrics on the Datadog console.

--- a/en_US/observability/prometheus.md
+++ b/en_US/observability/prometheus.md
@@ -13,7 +13,7 @@ EMQX supports two methods for integrating Prometheus metrics monitoring:
 - **Pull Mode**: Prometheus directly collects metrics through EMQX's REST API.
 - **Push Mode**: EMQX pushes metrics to the Pushgateway service, from which Prometheus collects the metrics.
 
-This page introduces the configuration steps for both methods. You can click **Management** -> **Monitoring** in the left navigation menu of the EMQX Dashboard, and in the **Integration** tab, select **Prometheus** to perform the configuration. You can also click the **Help** button on the page to view specific configuration steps for each mode.
+This page introduces the configuration steps for both methods. For a curated reference of the metric series exposed on the endpoints below — including the ones worth alerting on — see [Broker Health Indicators](./broker-health-indicators.md). You can click **Management** -> **Monitoring** in the left navigation menu of the EMQX Dashboard, and in the **Integration** tab, select **Prometheus** to perform the configuration. You can also click the **Help** button on the page to view specific configuration steps for each mode.
 
 ## Configure Pull Mode Integration
 

--- a/zh_CN/observability/broker-health-indicators.md
+++ b/zh_CN/observability/broker-health-indicators.md
@@ -1,0 +1,316 @@
+# Broker 健康指标
+
+本页是用于监控 EMQX broker 的最常用 Prometheus 指标的精选参考。请配合 [集成 Prometheus](./prometheus.md) 一起使用——后者介绍了如何暴露和抓取这些指标。
+
+本页将健康指标分为四个领域：
+
+1. **系统（System）** —— 操作系统和 Erlang 虚拟机资源。
+2. **Broker** —— 连接与消息流量，以及 broker 状态。
+3. **认证与授权（Authentication and authorization）** —— 连接时的身份校验和每条消息的 ACL 决策。
+4. **数据集成（Data integration）** —— 规则、动作、连接器和桥接。
+
+所有指标都通过 EMQX 的 Prometheus 端点（`/api/v5/prometheus/stats`、`/api/v5/prometheus/auth` 与 `/api/v5/prometheus/data_integration`）暴露。端点详情以及 `mode` 查询参数请参见 [集成 Prometheus](./prometheus.md#配置-pull-模式集成)。
+
+::: tip 关于采集器默认值
+
+带 `emqx_` 前缀的指标始终启用。带 `erlang_vm_` 前缀的、更丰富的 Erlang VM 指标来自上游 Prometheus Erlang exporter，在 EMQX 6.0 及更新版本中**默认关闭**。如果需要进程数、按分配器拆分的内存、GC / 调度器统计等指标，可将 `prometheus.collectors.vm_system_info`、`vm_memory`、`vm_statistics` 等设置为 `enabled` 启用对应采集器。
+
+:::
+
+## 系统
+
+最贴近硬件层的信号。broker 出现异常时，通常这一类指标会最先发生变化。
+
+### CPU
+
+- `emqx_vm_cpu_use` —— CPU 使用率（百分比）。
+- `emqx_vm_cpu_idle` —— CPU 空闲率（百分比）。
+
+### 内存
+
+- `emqx_vm_total_memory` —— 系统总内存（字节）。
+- `emqx_vm_used_memory` —— 系统已用内存（字节）。
+- `erlang_vm_memory_processes`、`erlang_vm_memory_atom`、`erlang_vm_memory_binary`、`erlang_vm_memory_ets`、`erlang_vm_memory_code`、`erlang_vm_memory_system` —— 按分配器拆分的内存（需启用 `vm_memory` 采集器）。
+
+### 文件描述符
+
+- `emqx_vm_max_fds` —— broker 进程的软 FD 上限（ulimit）。
+
+### Erlang 进程与调度器负载
+
+- `emqx_vm_run_queue` —— 当前调度器运行队列长度。长期不为零表示 CPU 饱和。
+- `emqx_vm_process_messages_in_queues` —— 所有 Erlang 进程邮箱长度之和。数值持续偏大或增长，表明某个进程处理不过来。
+- `erlang_vm_process_count` —— 当前 Erlang 进程数（需启用 `vm_system_info` 采集器）。
+- `erlang_vm_process_limit` —— 配置的 Erlang 进程数上限。
+
+### 内部邮箱看门狗
+
+- `emqx_vm_mnesia_tm_mailbox_size` —— Mnesia 事务管理器邮箱深度；偏大表示事务竞争。
+- `emqx_vm_broker_pool_max_mailbox_size` —— broker 派发进程池中最大的邮箱长度；偏大表示订阅侧出现背压。
+
+### 运行时长
+
+- `emqx_vm_uptime_ms` —— broker 已运行时间（毫秒）。突然降到很小值意味着节点重启。
+
+### 集群复制健康（Mria）
+
+- `emqx_mria_lag` —— 每个 replicant 节点的复制延迟。
+- `emqx_mria_replicants` —— replicant 节点数量。
+- `emqx_mria_bootstrap_time` —— 最近一次引导所用时间。
+- `emqx_mria_message_queue_len` —— Mria 邮箱长度。
+
+### 过载保护
+
+- `emqx_overload_protection_new_conn` —— 因过载而被拒绝的连接数。
+- `emqx_overload_protection_gc` —— 过载保护强制触发的 GC 次数。
+- `emqx_overload_protection_hibernation` —— 触发的进程休眠次数。
+- `emqx_overload_protection_delay_ok` —— 成功施加延迟的次数。
+- `emqx_overload_protection_delay_timeout` —— 延迟尝试超时的次数。
+
+## Broker
+
+最关键的运行指标。重点关注消息相关计数器的速率，尤其是各种 `dropped` 序列。
+
+### 集群拓扑
+
+- `emqx_cluster_nodes_running` —— 集群中正在运行的节点数。
+- `emqx_cluster_nodes_stopped` —— 集群中已停止的节点数。大于零时应报警。
+- `emqx_conf_sync_txid` —— 最近一次应用的集群配置事务 ID。各节点之间不一致表示同步异常。
+
+### License（企业版）
+
+- `emqx_license_expiry_at` —— License 过期时间（UNIX epoch 秒）。
+- `emqx_license_issued_at` —— License 签发时间。
+- `emqx_license_max_sessions` —— License 允许的最大会话数。
+- `emqx_cert_expiry_at` —— 监听器证书过期时间。
+
+### 连接、会话与 Channel
+
+- `emqx_connections_count` —— 当前连接数。
+- `emqx_connections_max` —— 启动以来连接数峰值。
+- `emqx_live_connections_count` —— 当前已建立（TCP 在线）的客户端数量。
+- `emqx_live_connections_max` —— 在线连接峰值。
+- `emqx_sessions_count` —— 活跃会话数（包含客户端当前已断开的持久会话）。
+- `emqx_sessions_max` —— 会话峰值。
+- `emqx_cluster_sessions_count` —— 集群范围内的会话数。
+- `emqx_cluster_sessions_max` —— 集群范围内会话峰值。
+- `emqx_channels_count` —— Channel 进程数（每个已连接客户端对应一个）。
+- `emqx_channels_max` —— Channel 数量峰值。
+
+### 订阅与主题
+
+- `emqx_subscriptions_count` —— 订阅数。
+- `emqx_subscriptions_max` —— 订阅数峰值。
+- `emqx_subscriptions_shared_count` —— 共享订阅数。
+- `emqx_subscriptions_shared_max` —— 共享订阅数峰值。
+- `emqx_subscribers_count` —— 订阅者进程数。
+- `emqx_topics_count` —— 不同主题数。
+- `emqx_topics_max` —— 主题数峰值。
+- `emqx_routes_count` —— 路由表大小。
+- `emqx_routes_max` —— 路由表大小峰值。
+- `emqx_durable_subscriptions_count` —— 持久会话订阅数。
+- `emqx_durable_subscriptions_max` —— 持久会话订阅数峰值。
+
+### 保留、延迟与禁用列表
+
+- `emqx_retained_count` —— 保留消息数。
+- `emqx_retained_max` —— 保留消息数峰值。
+- `emqx_delayed_count` —— 延迟发布队列长度。
+- `emqx_delayed_max` —— 延迟队列长度峰值。
+- `emqx_banned_count` —— 被禁用的客户端 / 用户名 / IP 条目数。
+
+### 消息
+
+- `emqx_messages_received` —— 从客户端收到的应用层消息数。
+- `emqx_messages_sent` —— 发送给客户端的应用层消息数。
+- `emqx_messages_publish` —— 已分发的 PUBLISH 报文数。
+- `emqx_messages_delivered` —— 投递给订阅者的次数（一条消息可能产生多次投递）。
+- `emqx_messages_acked` —— 收到的订阅者确认数。
+- `emqx_messages_forward` —— 跨节点转发的消息数。
+- `emqx_messages_retained` —— 保留消息事件数。
+- `emqx_messages_delayed` —— 延迟发布入队次数。
+
+### 消息丢弃（最早出现的异常信号）
+
+- `emqx_messages_dropped` —— 丢弃消息总数。
+- `emqx_messages_dropped_expired` —— 因超过消息过期时间被丢弃。
+- `emqx_messages_dropped_no_subscribers` —— 因没有匹配订阅者被丢弃。
+- `emqx_messages_dropped_quota_exceeded` —— 因触发每客户端配额被丢弃。
+- `emqx_messages_dropped_receive_maximum` —— 因订阅者 MQTT v5 的 receive-maximum 配额被丢弃。
+
+### 单订阅者投递丢弃
+
+- `emqx_delivery_dropped` —— 投递丢弃总数。
+- `emqx_delivery_dropped_expired` —— 投递前消息已过期。
+- `emqx_delivery_dropped_no_local` —— MQTT v5 No-Local 规则。
+- `emqx_delivery_dropped_qos` —— 不支持的 QoS。
+- `emqx_delivery_dropped_queue_full` —— 订阅者的消息队列已满。
+- `emqx_delivery_dropped_too_large` —— 超出订阅者允许的最大报文大小。
+
+### 字节
+
+- `emqx_bytes_received` —— 累计接收字节数。
+- `emqx_bytes_sent` —— 累计发送字节数。
+
+### 报文层（适用于协议级排查仪表盘）
+
+- `emqx_packets_received` / `emqx_packets_sent` —— 累计报文数。
+- `emqx_packets_connect` —— 收到的 CONNECT 报文数。
+- `emqx_packets_connack_sent` —— 发送的 CONNACK 报文数。
+- `emqx_packets_connack_error` —— 带非零 Reason Code 的 CONNACK 数（大多数单客户端 AUTHN 失败会在此体现）。
+- `emqx_packets_disconnect_received` / `emqx_packets_disconnect_sent` —— DISCONNECT 的收 / 发数。
+- `emqx_packets_publish_received` / `emqx_packets_publish_sent` —— PUBLISH 的收 / 发数。
+- `emqx_packets_publish_error` —— 未能被接收的 PUBLISH 数。
+- `emqx_packets_publish_auth_error` —— 被授权拒绝的 PUBLISH 数。
+- `emqx_packets_puback_*`、`emqx_packets_pubrec_*`、`emqx_packets_pubrel_*`、`emqx_packets_pubcomp_*` —— QoS 1 / 2 确认计数器。
+- `emqx_packets_subscribe_received` / `emqx_packets_suback_sent` / `emqx_packets_subscribe_error` / `emqx_packets_subscribe_auth_error` —— SUBSCRIBE 接收 / 失败 / 被 AUTHZ 拒绝。
+- `emqx_packets_unsubscribe_received` / `emqx_packets_unsuback_sent` / `emqx_packets_unsubscribe_error`。
+- `emqx_packets_pingreq_received` / `emqx_packets_pingresp_sent` —— 保活活动。
+
+### 客户端生命周期（钩子触发计数）
+
+- `emqx_client_connect` —— 收到 CONNECT。
+- `emqx_client_connack` —— 已发送 CONNACK。
+- `emqx_client_connected` —— 触发了 `client.connected` 钩子。
+- `emqx_client_disconnected` —— 触发了 `client.disconnected` 钩子。
+- `emqx_client_disconnected_reason` —— 按原因聚合的断开次数。
+- `emqx_client_subscribe` / `emqx_client_unsubscribe` —— 订阅 / 取消订阅钩子触发数。
+
+### 会话生命周期
+
+- `emqx_session_created` —— 创建的会话数。
+- `emqx_session_resumed` —— 恢复的持久会话数。
+- `emqx_session_takenover` —— 被新客户端接管的会话数。
+- `emqx_session_discarded` —— 被丢弃的会话数（Clean Start 覆盖已有会话）。
+- `emqx_session_terminated` —— 已终止的会话数。
+
+## 认证与授权
+
+当 HTTP、LDAP 或数据库后端处于认证链路上、需要判断到底是 broker 慢还是后端慢/失败时，这些指标特别有用。
+
+### 连接时认证结果
+
+- `emqx_authentication_success` —— 认证成功次数（不含匿名通过）。
+- `emqx_authentication_success_anonymous` —— 匿名通过次数。
+- `emqx_authentication_failure` —— 认证失败次数。
+
+### 授权决策
+
+- `emqx_authorization_allow` —— 决策为 allow 的次数。
+- `emqx_authorization_deny` —— 决策为 deny 的次数。
+- `emqx_authorization_nomatch` —— 没有匹配规则的次数（退回到 `no_match` 配置）。
+- `emqx_authorization_matched_allow` —— 命中 allow 规则的次数。
+- `emqx_authorization_matched_deny` —— 命中 deny 规则的次数。
+- `emqx_authorization_cache_hit` —— 缓存命中次数。
+- `emqx_authorization_cache_miss` —— 缓存未命中次数。
+- `emqx_authorization_superuser` —— 超级用户旁路次数。
+
+### 认证链状态
+
+- `emqx_authn_total` —— 已配置的认证 provider 数量。
+- `emqx_authn_enable` —— 每个 provider 的启用标志（0 / 1）。
+- `emqx_authn_status` —— 每个 provider 的资源状态。
+- `emqx_authn_users_count` —— 每个 provider 的用户记录数（适用于密码、mnesia 或基于数据库的 provider）。
+
+### 认证 provider 运行时计数
+
+- `emqx_authn_success` —— 每个 provider 命中成功的次数。
+- `emqx_authn_failed` —— 每个 provider 失败的次数。
+- `emqx_authn_nomatch` —— 每个 provider 选择忽略的次数（链路继续向下匹配）。
+- `emqx_authn_latency` —— 每个 provider 的后端延迟。
+
+### 授权数据源状态
+
+- `emqx_authz_total` —— 已配置的授权数据源数量。
+- `emqx_authz_enable` —— 每个数据源的启用标志（0 / 1）。
+- `emqx_authz_status` —— 每个数据源的资源状态。
+- `emqx_authz_rules_count` —— 每个数据源的规则记录数（适用于文件、mnesia 或基于数据库的数据源）。
+
+### 授权数据源运行时计数
+
+- `emqx_authz_allow` —— 每个数据源决策为 allow 的次数。
+- `emqx_authz_deny` —— 每个数据源决策为 deny 的次数。
+- `emqx_authz_nomatch` —— 每个数据源选择忽略的次数（链路继续向下匹配）。
+- `emqx_authz_latency` —— 每个数据源的后端延迟。
+
+### 内置数据库规模
+
+- `emqx_authn_builtin_record_count` —— 内置认证数据库中的用户数。
+- `emqx_authz_builtin_record_count` —— 内置授权数据库中的规则数。
+
+## 数据集成
+
+流水线视图：流量进入规则引擎，扇出到连接器与动作，最终落到外部系统。每一层都暴露各自的计数器；按顺序读取这些计数器，就能找出消息是在哪一层流失的。
+
+### 资源清单
+
+- `emqx_rules_count` —— 已配置的规则数。
+- `emqx_actions_count` —— 已配置的动作数。
+- `emqx_connectors_count` —— 已配置的连接器数。
+- `emqx_schema_registrys_count` —— Schema Registry 条目数。
+
+### 单资源状态
+
+- `emqx_rule_enable` —— 规则启用标志（0 / 1）。
+- `emqx_action_enable` —— 动作启用标志（0 / 1）。
+- `emqx_action_status` —— 动作资源状态。
+- `emqx_connector_enable` —— 连接器启用标志（0 / 1）。
+- `emqx_connector_status` —— 连接器资源状态。
+
+### 规则引擎 —— 单规则计数
+
+- `emqx_rule_matched` —— 命中规则 WHERE 子句的消息数。
+- `emqx_rule_passed` —— 通过规则的消息数。
+- `emqx_rule_failed` —— 规则处理失败次数。
+- `emqx_rule_failed_exception` —— 规则执行中抛出 Erlang 异常的次数。
+- `emqx_rule_failed_no_result` —— SQL 没有产生结果的次数。
+
+### 规则引擎 —— 动作子计数
+
+- `emqx_rule_actions_total` —— 规则触发的动作调用总数。
+- `emqx_rule_actions_success` —— 动作返回成功的次数。
+- `emqx_rule_actions_failed` —— 动作失败次数。
+- `emqx_rule_actions_failed_unknown` —— 未知原因失败次数。
+- `emqx_rule_actions_failed_out_of_service` —— 下游资源不健康次数。
+- `emqx_rule_actions_discarded` —— 动作被丢弃次数（例如被限流）。
+
+### 动作吞吐
+
+- `emqx_action_matched` —— 路由到该动作的消息数。
+- `emqx_action_received` —— 进入动作队列的次数。
+- `emqx_action_success` —— 动作调用成功次数。
+- `emqx_action_failed` —— 动作调用失败次数。
+- `emqx_action_late_reply` —— 响应在超时之后才到达的次数。
+- `emqx_action_retried` —— 重试次数。
+- `emqx_action_retried_success` —— 重试后成功的次数。
+- `emqx_action_retried_failed` —— 重试用尽仍失败的次数。
+
+### 动作队列与在飞请求
+
+- `emqx_action_inflight` —— 正在处理的请求数。
+- `emqx_action_queuing` —— 队列中（等待派发）的请求数。
+
+### 动作丢弃
+
+任一序列出现非零速率，都是下游系统不健康或动作配置不当的明显信号。
+
+- `emqx_action_dropped` —— 动作层丢弃总数。
+- `emqx_action_dropped_queue_full` —— 触发队列上限。
+- `emqx_action_dropped_resource_stopped` —— 目标资源已停止。
+- `emqx_action_dropped_resource_not_found` —— 目标资源缺失。
+- `emqx_action_dropped_expired` —— 派发前消息已过期。
+- `emqx_action_dropped_other` —— 其他原因。
+
+## 最小化的"Broker 异常"面板
+
+如果只能在一个页面里塞下少量曲线，下面这几条是负载承担最重的指标。大多数生产问题在事件发生后几秒内，都会让其中至少一条出现明显波动：
+
+- `rate(emqx_messages_dropped[1m])` —— 不为零说明 broker 在拒绝或丢弃工作。
+- `rate(emqx_action_dropped[1m])` —— 数据集成层在丢弃工作。
+- `emqx_cluster_nodes_stopped` —— 大于零说明有节点掉线。
+- `rate(emqx_overload_protection_new_conn[1m])` —— broker 正在主动拒绝新连接。
+- `rate(emqx_authentication_failure[1m])` —— 认证失败速率突增通常意味着后端异常或受到攻击。
+- `emqx_vm_run_queue` —— 持续大于零说明 CPU 饱和。
+- `emqx_vm_process_messages_in_queues` —— 数值偏大说明进程邮箱出现积压。
+- `emqx_mria_lag` —— 持续超过几秒说明复制开始落后。
+- `emqx_license_expiry_at - time()`（企业版） —— License 到期倒计时。

--- a/zh_CN/observability/overview.md
+++ b/zh_CN/observability/overview.md
@@ -16,6 +16,10 @@ EMQX 通过包括日志在内的一系列的可观测性功能帮助用户进行
 
   [Prometheus](https://prometheus.io/) 是由 SoundCloud 开源的监控告警解决方案，支持多维数据模型、灵活的查询语言、强大的告警管理等特性。EMQX 支持集成 Prometheus 用于监测系统指标，同时还支持向 `pushgateway` 推送指标。
 
+- [Broker 健康指标](./broker-health-indicators.md)
+
+  用于监控 EMQX broker 的常用 Prometheus 指标精选参考，按系统、broker、认证与授权、数据集成四个领域组织。请配合 Prometheus 集成文档一起使用，用于决定抓取哪些指标、对哪些指标设置告警以及在仪表盘上展示哪些曲线。
+
 - [集成 Datadog](./datadog.md)
 
   [Datadog](https://www.datadoghq.com/) 是一款可观测性平台，它为应用程序提供统一、实时的可观测性和安全性解决方案。EMQX 支持集成 Datadog 用于了解 EMQX 运行状态、监测和排查系统性能问题，还可以在 Datadog 控制台上查看 EMQX 指标。

--- a/zh_CN/observability/prometheus.md
+++ b/zh_CN/observability/prometheus.md
@@ -13,7 +13,7 @@ EMQX 支持 2 种方式实现 Prometheus 指标监控集成：
 - **Pull 模式**：Prometheus 直接通过 EMQX 的 REST API 采集指标。
 - **Push 模式**：EMQX 推送指标到 Pushgateway 服务，再由 Prometheus 从 Pushgateway 服务中采集指标。
 
-本页将介绍这两种方式的配置步骤。您可以在 EMQX Dashboard 中点击左侧导航目录中的**管理** -> **监控**，在**监控集成**标签页，选择 **Prometheus** 进行相关的集成配置。您还可以点击页面上的**帮助**按钮查看每个模式的具体配置步骤。
+本页将介绍这两种方式的配置步骤。如需查看下方端点所暴露的指标精选参考（包括建议告警的指标），请参见 [Broker 健康指标](./broker-health-indicators.md)。您可以在 EMQX Dashboard 中点击左侧导航目录中的**管理** -> **监控**，在**监控集成**标签页，选择 **Prometheus** 进行相关的集成配置。您还可以点击页面上的**帮助**按钮查看每个模式的具体配置步骤。
 
 <!-- TODO 5.5 将 Dashboard 上的完整配置步骤合并到文档中 -->
 


### PR DESCRIPTION
## Summary

Adds a new reference page, **Broker Health Indicators**, under `en_US/observability/` (mirrored in `zh_CN/`), with a curated list of the most useful Prometheus metrics for monitoring an EMQX broker, organized into four areas:

1. System (OS / Erlang VM)
2. Broker (connections, sessions, messages, drops)
3. Authentication and authorization
4. Data integration (rules, actions, connectors)

Also includes a short "broker-is-sick" panel suggesting the load-bearing series to chart and alert on.

## Wiring

- Added to `dir.yaml` left-nav, right after the existing Prometheus integration page.
- Linked from `observability/overview` (EN + zh_CN).
- Linked from `observability/prometheus` (EN + zh_CN) so readers configuring the scrape know where to look up what each series means.

## Test plan

- [ ] Preview locally and confirm the page renders, the left-nav entry appears under **Logs and Observability**, and the cross-links from overview / prometheus resolve.
- [ ] Spot-check a few metric names against `/api/v5/prometheus/stats` and `/api/v5/prometheus/data_integration` on a running broker.