### PR TITLE
docs(scopes): warn that broad scopes are administrator-equivalent

### DIFF
--- a/en_US/admin/api.md
+++ b/en_US/admin/api.md
@@ -345,6 +345,14 @@ In addition to these API-key scopes, Dashboard login users have four login-only 
 Scope names are stable identifiers that do not change across EMQX upgrades. Even if a route's OpenAPI tag is renamed, a key configured with the same scope keeps working.
 :::
 
+::: warning Treat `system` as administrator-equivalent
+
+`system` covers configuration-management endpoints (`/configs*`, `/data/*`, `/listeners*`, ...). A key holding `system` can update any configuration subtree and import backup archives, both of which can be used to change settings that other, finer-grained scopes (such as `audit`, `access_control`, or `monitoring`) would normally protect.
+
+Combining `system` with a restricted scope list on the same key does not reliably enforce the restriction. Reserve `system` for keys that already have administrative trust, and apply the principle of least privilege by granting only the scopes the integration actually needs.
+
+:::
+
 Dashboard login, SSO callbacks, and API key self-management endpoints (for example, `/api_key`) do not accept API-key authentication, regardless of the key's `scopes` configuration. This is a built-in Dashboard security boundary, unrelated to the scope model.
 
 #### Default Behavior of `scopes`

--- a/en_US/admin/api.md
+++ b/en_US/admin/api.md
@@ -347,9 +347,9 @@ Scope names are stable identifiers that do not change across EMQX upgrades. Even
 
 ::: warning Treat `system` as administrator-equivalent
 
-`system` covers configuration-management endpoints (`/configs*`, `/data/*`, `/listeners*`, ...). A key holding `system` can update any configuration subtree and import backup archives, both of which can be used to change settings that other, finer-grained scopes (such as `audit`, `access_control`, or `monitoring`) would normally protect.
+`system` covers configuration-management endpoints (`/configs*`, `/data/*`, `/listeners*`, ...). A key holding `system` can update any configuration subtree or restore EMQX data from backup archives. Either action can change settings that finer-grained scopes, such as `audit`, `access_control`, or `monitoring`, would normally protect.
 
-Combining `system` with a restricted scope list on the same key does not reliably enforce the restriction. Reserve `system` for keys that already have administrative trust, and apply the principle of least privilege by granting only the scopes the integration actually needs.
+Combining `system` with a restricted scope list on the same key does not reliably enforce the restriction. Reserve `system` for keys that already have administrative trust, and apply the principle of least privilege by granting only the scopes the key actually needs.
 
 :::
 
@@ -507,4 +507,3 @@ When an error happens, the error code is returned in JSON format by the Body:
 | UPDATE_FAILED                                  | Update fails                                                 |
 | REST_FAILED                                    | Reset source or configuration fails                          |
 | CLIENT_NOT_RESPONSE                            | Client not responding                                        |
-

--- a/en_US/dashboard/system.md
+++ b/en_US/dashboard/system.md
@@ -45,15 +45,15 @@ When you create or edit a user, the **Scopes** field is optional. If you leave i
 
 ![user_scopes](./assets/user_scopes.png)
 
-::: warning Treat `system`, `user_management`, and `api_key_management` as administrator-equivalent
+::: warning Treat broad scopes as administrator-equivalent
 
-A few scopes are inherently broad and effectively grant administrator capabilities even when other scopes are not assigned:
+The following scopes are inherently broad and effectively grant administrator capabilities even when other scopes are not assigned:
 
-- `system` covers configuration management (`/configs*`, `/data/*`, ...). A user holding `system` can update any configuration subtree and import backup archives that include stored user and key records.
+- `system` covers configuration management (`/configs*`, `/data/*`, ...). A user holding `system` can update any configuration subtree or restore backup archives that contain stored user and API key records.
 - `user_management` lets the holder create or modify other Dashboard users, including ones with any scope set.
 - `api_key_management` lets the holder create or modify API keys, including ones with any scope set.
 
-Granting any of these together with a restricted scope list on the same user does not reliably enforce the restriction — the user can reach the restricted areas via configuration changes, backup import, or by provisioning a new account or key for themselves. Reserve these three scopes for users you fully trust, and apply the principle of least privilege by granting only the specific scopes a user actually needs.
+Granting any of these scopes together with a restricted scope list on the same user does not reliably enforce the restriction. The user can reach restricted areas through configuration changes, backup import, or by provisioning a new account or key. Reserve these three scopes for fully trusted users, and grant only the scopes a user actually needs.
 
 :::
 

--- a/en_US/dashboard/system.md
+++ b/en_US/dashboard/system.md
@@ -45,6 +45,18 @@ When you create or edit a user, the **Scopes** field is optional. If you leave i
 
 ![user_scopes](./assets/user_scopes.png)
 
+::: warning Treat `system`, `user_management`, and `api_key_management` as administrator-equivalent
+
+A few scopes are inherently broad and effectively grant administrator capabilities even when other scopes are not assigned:
+
+- `system` covers configuration management (`/configs*`, `/data/*`, ...). A user holding `system` can update any configuration subtree and import backup archives that include stored user and key records.
+- `user_management` lets the holder create or modify other Dashboard users, including ones with any scope set.
+- `api_key_management` lets the holder create or modify API keys, including ones with any scope set.
+
+Granting any of these together with a restricted scope list on the same user does not reliably enforce the restriction — the user can reach the restricted areas via configuration changes, backup import, or by provisioning a new account or key for themselves. Reserve these three scopes for users you fully trust, and apply the principle of least privilege by granting only the specific scopes a user actually needs.
+
+:::
+
 #### Role Changes and Scope Compatibility
 
 When you change a user's role, EMQX checks whether the user's current scopes are compatible with the new role. If they are not, the request is rejected with HTTP 400. To resolve this, include a `scopes` list in the same request that is valid for the new role.

--- a/zh_CN/admin/api.md
+++ b/zh_CN/admin/api.md
@@ -341,6 +341,14 @@ EMQX 5.10 提供 10 个 Scope，可在创建 API 密钥时自由组合：
 Scope 是稳定标识符，不会随 EMQX 版本升级而改名；即便某个 API 的 OpenAPI tag 发生变化，只要您使用的是同一个 Scope，密钥行为保持不变。
 :::
 
+::: warning 将 `system` 视为等同管理员权限
+
+`system` 覆盖配置管理端点（`/configs*`、`/data/*`、`/listeners*` 等）。持有 `system` 的密钥可以更新任意配置子树，或从备份文件中恢复 EMQX 数据。任一操作都可能更改通常由更细粒度 Scope（如 `audit`、`access_control` 或 `monitoring`）保护的设置。
+
+将 `system` 与受限 Scope 列表组合到同一个密钥上，并不能可靠地强制执行该限制。仅将 `system` 授予已具备管理员信任级别的密钥，并遵循最小权限原则，只授予该密钥实际需要的 Scope。
+
+:::
+
 Dashboard 自身的登录、SSO 回调以及 API 密钥自身的管理接口（例如 `/api_key`）不接受 API 密钥认证，与密钥的 `scopes` 配置无关。这属于 Dashboard 的内置安全边界，与 Scope 模型无关。
 
 #### Scope 的默认行为

--- a/zh_CN/dashboard/system.md
+++ b/zh_CN/dashboard/system.md
@@ -44,6 +44,18 @@ EMQX Dashboard 中的**系统设置**菜单提供一系列管理功能入口，�
 
 ![user_scopes](./assets/user_scopes.png)
 
+::: warning 将宽泛 Scope 视为等同管理员权限
+
+以下 Scope 天然覆盖范围较广，即使未分配其他 Scope，也实际上授予管理员能力：
+
+- `system` 覆盖配置管理（`/configs*`、`/data/*` 等）。持有 `system` 的用户可以更新任意配置子树，或恢复包含已存储用户和 API 密钥记录的备份文件。
+- `user_management` 允许持有者创建或修改其他 Dashboard 用户，包括具有任意 Scope 集的用户。
+- `api_key_management` 允许持有者创建或修改 API 密钥，包括具有任意 Scope 集的密钥。
+
+将其中任一 Scope 与受限 Scope 列表组合到同一个用户上，并不能可靠地强制执行该限制。该用户可通过配置变更、备份恢复，或为自己创建新的账号或密钥来访问受限区域。仅将这三个 Scope 授予您完全信任的用户，并遵循最小权限原则，只授予用户实际需要的具体 Scope。
+
+:::
+
 #### 角色变更与 Scope 兼容性
 
 变更用户角色时，EMQX 会检查该用户当前的 Scope 是否与新角色兼容。如果不兼容，请求将返回 HTTP 400。要解决此问题，请在同一请求中提供一个对新角色有效的 `scopes` 列表。
@@ -108,4 +120,3 @@ EMQX Dashboard 中的**系统设置**菜单提供一系列管理功能入口，�
 此外，设置菜单中还包含一个开关，用于启用或禁用**规则**页面中的 [SQL 生成器](../data-integration/rule-get-started.md#sql-generator)功能。
 
 <img src="./assets/settings_ee.png" alt="settings_ee" style="zoom:67%;" />
-


### PR DESCRIPTION
## Summary

Some scopes are inherently broad and effectively grant administrator capabilities regardless of what other scopes are assigned to the same user or key. The scope catalogue table doesn't make this obvious today, and operators can land in a misconfiguration where they assign one broad scope alongside a restricted list and expect the restriction to bind.

This PR adds two warning callouts:

- `en_US/admin/api.md` (Built-in Scopes for API keys): flags `system` as administrator-equivalent. A key holding `system` can update any configuration subtree and import backup archives, which reaches behaviour that other finer-grained scopes (`audit`, `access_control`, `monitoring`, ...) would otherwise protect.

- `en_US/dashboard/system.md` (Login User Scopes): broader callout covering all three Login User scopes that effectively grant administrator capability — `system` (configuration management), `user_management` (can create or modify other users with any scope set), and `api_key_management` (same, for API keys).

Both callouts recommend treating the named scopes as administrator-equivalent and applying the principle of least privilege.

No code change.