### PR TITLE
docs(tune): add tcp_retries2 optimization

### DIFF
--- a/en_US/tutorial/tune.md
+++ b/en_US/tutorial/tune.md
@@ -136,6 +136,12 @@ Timeout for FIN-WAIT-2 Sockets:
 sysctl -w net.ipv4.tcp_fin_timeout=15
 ```
 
+Reduce TCP packet retransmission count:
+
+```
+sysctl -w net.ipv4.tcp_retries2=5
+```
+
 ## Erlang VM Tuning
 
 
@@ -199,6 +205,7 @@ docker run -d --name emqx -p 18083:18083 -p 1883:1883 \
     --sysctl net.ipv4.tcp_wmem='1024 4096 16777216\ \
     --sysctl net.ipv4.tcp_max_tw_buckets=1048576 \
     --sysctl net.ipv4.tcp_fin_timeout=15 \
+    --sysctl net.ipv4.tcp_retries2=5 \
     emqx/emqx:latest
 ```
 

--- a/zh_CN/tutorial/tune.md
+++ b/zh_CN/tutorial/tune.md
@@ -108,6 +108,10 @@ FIN-WAIT-2 Socket 超时设置:
 ```bash
 sysctl -w net.ipv4.tcp_fin_timeout=15
 ```
+减少 TCP 报文重传次数:
+```bash
+sysctl -w net.ipv4.tcp_retries2=5
+```
 
 ## Erlang 虚拟机参数
 
@@ -166,6 +170,7 @@ docker run -d --name emqx -p 18083:18083 -p 1883:1883 -p 4369:4369 \
     --sysctl net.ipv4.tcp_wmem=1024 4096 16777216 \
     --sysctl net.ipv4.tcp_max_tw_buckets=1048576 \
     --sysctl net.ipv4.tcp_fin_timeout=15 \
+    --sysctl net.ipv4.tcp_retries2=5 \
     emqx/emqx:latest
 ```
 


### PR DESCRIPTION
Reduce TCP packet retransmission count by setting net.ipv4.tcp_retries2=5. The default value of 15 leads to an excessively long total retransmission duration, blocking the Erlang process that sends TCP packets while delivering messages to the TCP driver, and may cause OOM in extreme cases.