### PR TITLE
docs(tune): add tcp_retries2 optimization

### DIFF
--- a/en_US/performance/tune.md
+++ b/en_US/performance/tune.md
@@ -144,6 +144,12 @@ Timeout for FIN-WAIT-2 Sockets:
 sysctl -w net.ipv4.tcp_fin_timeout=15
 ```
 
+Reduce TCP packet retransmission count:
+
+```bash
+sysctl -w net.ipv4.tcp_retries2=5
+```
+
 ## Erlang VM Tuning
 
 Tune and optimize the Erlang VM in `etc/emqx.conf` file:

--- a/zh_CN/performance/tune.md
+++ b/zh_CN/performance/tune.md
@@ -133,6 +133,12 @@ FIN-WAIT-2 Socket 超时设置:
 sysctl -w net.ipv4.tcp_fin_timeout=15
 ```
 
+减少 TCP 报文重传次数:
+
+```bash
+sysctl -w net.ipv4.tcp_retries2=5
+```
+
 ## Erlang 虚拟机参数
 
 优化设置 Erlang 虚拟机启动参数，配置文件 /etc/emqx/emqx.conf:


### PR DESCRIPTION
Add `net.ipv4.tcp_retries2=5` to the TCP stack tuning section of `tune.md` (both English and Chinese).

Reduce TCP packet retransmission count. The default value of `tcp_retries2` is 15, which results in an excessively long total retransmission duration; the Erlang process sending TCP packets can be blocked for too long while delivering messages to the TCP driver, and may cause OOM in extreme cases.

Port of the release-4.4 PR.