### PR TITLE
docs: security note for WebSocket forwarded-address header trust

### DIFF
--- a/en_US/access-control/security-checklist.md
+++ b/en_US/access-control/security-checklist.md
@@ -11,6 +11,7 @@ This checklist helps you review an EMQX deployment before exposing it to product
 - If nodes have multiple interfaces, bind Erlang distribution traffic to the private network interface only.
 - If you deploy EMQX behind a load balancer or TCP proxy, enable [Proxy Protocol](../deploy/cluster/lb.md) only on the listeners that need the real client IP address or client certificate details.
 - If Proxy Protocol is enabled for a listener, expose that address and port only to the designated proxy or load balancer. Enforce this in EMQX with `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]`, combined with network-level controls (firewall, private network, or Unix socket). Otherwise, a client that reaches the port directly can craft a PROXY v2 frame with arbitrary peer-cert fields and impersonate any identity.
+- If a WebSocket listener (`ws` or `wss`) is not behind a trusted proxy that overwrites the `x-forwarded-for` header, set `listeners.{type}.{name}.websocket.proxy_address_header = ""` (and `websocket.proxy_port_header = ""`) so that IP-based authorization rules, banned clients, flapping detection, and audit logs use the real TCP peer address. When the header is honored, the derived source IP is client-supplied unless a trusted proxy overwrites the header — a proxy that only appends to the inbound header does not protect it. See [Forwarded Client Address](../configuration/listener.md#forwarded-client-address-websocket-listeners).
 
 ## Phase 2: Erlang and Cluster
 

--- a/en_US/configuration/listener.md
+++ b/en_US/configuration/listener.md
@@ -137,6 +137,26 @@ where:
   - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
   - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
+## Forwarded Client Address (WebSocket Listeners)
+
+WebSocket and secure WebSocket listeners have two options that control how EMQX determines a client's source address when the listener sits behind a proxy or load balancer:
+
+- `websocket.proxy_address_header` (default: `x-forwarded-for`)
+- `websocket.proxy_port_header` (default: `x-forwarded-port`)
+
+When the configured header is present on the WebSocket upgrade request, EMQX uses the first (leftmost) entry of the header value as the client's source IP address (or port) instead of the address of the real TCP peer. The derived address is what IP-based authorization rules, banned clients, flapping detection, and audit and trace logs see as the client's source IP.
+
+::: warning Trust the forwarded address header only behind a trusted proxy
+
+The header value determines the client's apparent source IP, so it must be honored only when a trusted proxy sets it:
+
+- If the listener is directly reachable by clients (no proxy in front), any client can send the header and choose its own apparent source IP. Set `proxy_address_header = ""` and `proxy_port_header = ""` to always use the real TCP peer address.
+- If there is a proxy but it **appends** its observation to an inbound `X-Forwarded-For` header instead of overwriting or stripping it (appending is the default behavior of most proxies, for example NGINX's `$proxy_add_x_forwarded_for`), the leftmost entry that EMQX reads is still the one supplied by the client, so the source IP can still be spoofed. Configure the proxy to overwrite the header with the address it observed, use the [PROXY protocol](../deploy/cluster/lb.md) instead, or set the options to `""`.
+- Do not try to disable the mechanism by pointing the option at an unused header name: a client can send a header by any name. The empty string is the only value a client can never supply.
+
+When `proxy_protocol = true` is set on the listener, the client address comes from the PROXY protocol handshake, and these headers are not consulted.
+:::
+
 <!--To add QUIC-->
 
 <!--To add code sample for adding multiple listeners.-->

--- a/en_US/deploy/cluster/lb-nginx.md
+++ b/en_US/deploy/cluster/lb-nginx.md
@@ -306,6 +306,10 @@ http {
 }
 ```
 
+::: tip
+`$proxy_add_x_forwarded_for` appends `$remote_addr` to any `X-Forwarded-For` header already present in the inbound request, while EMQX reads the first (leftmost) entry of the header — which in the appended form is supplied by the client and can be spoofed. If EMQX uses this header as the client's source address (see [Forwarded Client Address](../../configuration/listener.md#forwarded-client-address-websocket-listeners)), overwrite the header with the address NGINX observed instead: `proxy_set_header X-Forwarded-For $remote_addr;`.
+:::
+
 ### Configure Reverse Proxy for MQTT WebSocket SSL
 
 You can configure NGINX to reverse proxy MQTT WebSocket and decrypt TLS connections, forwarding encrypted MQTT requests from clients to the backend MQTT servers to ensure communication security. Specify an HTTP domain name or IP address using `server_name`. To achieve this, you only need to add SSL and certificate-related parameters on top of the WebSocket-based configuration:

--- a/zh_CN/access-control/security-checklist.md
+++ b/zh_CN/access-control/security-checklist.md
@@ -11,6 +11,7 @@
 - 如果节点存在多个网卡接口，应将 Erlang 分布式通信仅绑定到私网接口。
 - 如果 EMQX 部署在负载均衡器或 TCP 代理之后，仅应在确实需要获取真实客户端 IP 或客户端证书信息的监听器上启用 [Proxy Protocol](../deploy/cluster/lb.md)。
 - 如果某个监听器启用了 Proxy Protocol，则该监听地址和端口只应暴露给指定的代理或负载均衡器，不能再直接对公网客户端开放。可在 EMQX 中通过 `listeners.{type}.{name}.access_rules = ["allow <trusted-LB-CIDR>", "deny all"]` 进行限制，并结合网络层控制（防火墙、私有网络或 Unix socket）。否则，能直接访问该端口的客户端可以伪造任意对端证书字段的 PROXY v2 帧，从而冒充任意身份。
+- 如果 WebSocket 监听器（`ws` 或 `wss`）前面没有会覆盖 `x-forwarded-for` 请求头的受信任代理，应设置 `listeners.{type}.{name}.websocket.proxy_address_header = ""`（以及 `websocket.proxy_port_header = ""`），使基于 IP 的授权规则、客户端封禁、连接抖动检测和审计日志使用真实的 TCP 对端地址。一旦启用该请求头，除非受信任代理覆盖它，派生出的源 IP 就是由客户端提供的——仅向入站请求头追加内容的代理并不能提供保护。详见 [WebSocket 监听器的转发客户端地址](../configuration/listener.md#websocket-监听器的转发客户端地址)。
 
 ## 阶段 2：Erlang 与集群
 

--- a/zh_CN/configuration/listener.md
+++ b/zh_CN/configuration/listener.md
@@ -133,6 +133,26 @@ listeners.wss.default {
 - `websocket.mqtt_path` 设置 WebSocket 的 MQTT 协议路径，默认为 `/mqtt`。
 - `ssl_options` 包括 SSL/TLS 配置选项，详细说明参见 [配置 SSL 监听器](#配置-ssl-监听器)。
 
+## WebSocket 监听器的转发客户端地址
+
+WebSocket 与安全 WebSocket 监听器提供两个配置项，用于在监听器位于代理或负载均衡器之后时决定 EMQX 如何获取客户端的源地址：
+
+- `websocket.proxy_address_header`（默认值：`x-forwarded-for`）
+- `websocket.proxy_port_header`（默认值：`x-forwarded-port`）
+
+当 WebSocket 升级请求中携带所配置的请求头时，EMQX 会使用该请求头值中第一个（最左侧的）条目作为客户端的源 IP 地址（或端口），而不再使用真实 TCP 对端的地址。基于 IP 的授权规则、客户端封禁、连接抖动检测以及审计与追踪日志所看到的客户端源 IP 都来自这个派生地址。
+
+::: warning 仅在受信任代理之后才可信任转发地址请求头
+
+该请求头的值决定了客户端的表观源 IP，因此只有在由受信任的代理设置该请求头时才可信任它：
+
+- 如果监听器可被客户端直接访问（前面没有代理），任何客户端都可以自行发送该请求头，从而任意选择自己的表观源 IP。此时应设置 `proxy_address_header = ""` 和 `proxy_port_header = ""`，使 EMQX 始终使用真实的 TCP 对端地址。
+- 如果前面有代理，但代理是将自身观察到的地址**追加**到入站 `X-Forwarded-For` 请求头之后，而不是覆盖或去除它（大多数代理默认为追加行为，例如 NGINX 的 `$proxy_add_x_forwarded_for`），那么 EMQX 读取的最左侧条目仍然是客户端提供的值，源 IP 依然可以被伪造。应将代理配置为使用其观察到的地址覆盖该请求头，或改用 [Proxy Protocol](../deploy/cluster/lb.md)，或将上述配置项设置为 `""`。
+- 不要试图通过将配置项指向一个未使用的请求头名称来“禁用”该机制：客户端可以发送任意名称的请求头。空字符串是客户端唯一无法提供的值。
+
+当监听器设置了 `proxy_protocol = true` 时，客户端地址来自 Proxy Protocol 握手，不会读取这些请求头。
+:::
+
 ## 将监听器关联到配置区域
 
 EMQX 中的每个监听器都与一个区域相关联，默认设置为名为 `default` 的逻辑区域。

--- a/zh_CN/deploy/cluster/lb-nginx.md
+++ b/zh_CN/deploy/cluster/lb-nginx.md
@@ -311,6 +311,10 @@ http {
 }
 ```
 
+::: tip
+`$proxy_add_x_forwarded_for` 会将 `$remote_addr` 追加到入站请求中已有的 `X-Forwarded-For` 请求头之后，而 EMQX 读取的是该请求头中第一个（最左侧的）条目——在追加模式下，该条目由客户端提供，可以被伪造。如果 EMQX 使用该请求头作为客户端源地址（参见 [WebSocket 监听器的转发客户端地址](../../configuration/listener.md#websocket-监听器的转发客户端地址)），请改为使用 NGINX 观察到的地址覆盖该请求头：`proxy_set_header X-Forwarded-For $remote_addr;`。
+:::
+
 ### 配置反向代理 MQTT WebSocket SSL
 
 您可以使用以下配置使 NGINX 反向代理 MQTT WebSocket 并解密 TLS 连接，将客户端加密的 MQTT 请求解密后转发至后端 MQTT 服务器，以确保通信安全性。需要使用  `server_name` 指定 HTTP 域名或 IP 地址。


### PR DESCRIPTION
## What

Operator hardening guidance for the WebSocket listener forwarded-address headers (`websocket.proxy_address_header` / `websocket.proxy_port_header`, defaults `x-forwarded-for` / `x-forwarded-port`). Release-6.0 counterpart of #3740:

- **Listener Configuration** (`configuration/listener.md`): new section documenting the two options and a security note — the header-derived source IP feeds IP-based authorization, banning, flapping detection, and audit/trace logs; it must only be trusted behind a proxy that *overwrites* the header. Explains why appending proxies do not protect it (EMQX reads the leftmost entry), that `""` is the only safe off value (a decoy header name can still be supplied by clients), and that PROXY protocol is unaffected.
- **Security Checklist** (`access-control/security-checklist.md`): new Phase 1 item next to the existing Proxy Protocol entries.
- **NGINX LB guide** (`deploy/cluster/lb-nginx.md`): tip next to the WebSocket examples noting that `$proxy_add_x_forwarded_for` appends (spoofable leftmost entry) and to use `$remote_addr` to overwrite when EMQX consumes the header.

zh_CN updated in lockstep with en_US. A 6.3-only follow-up documents the upcoming `proxy_address_allow` option.