### PR TITLE
docs: security note for WebSocket forwarded-address header trust (6.3, proxy_address_allow)

### DIFF
--- a/en_US/configuration/listener.md
+++ b/en_US/configuration/listener.md
@@ -137,6 +137,29 @@ where:
   - `certfile`: PEM file containing the SSL/TLS certificate chain for the listener. If the certificate is not directly issued by a root CA, the intermediate CA certificates should be appended after the listener certificate to form a chain.
   - `keyfile`: PEM file containing the private key corresponding to the SSL/TLS certificate.
 
+## Forwarded Client Address (WebSocket Listeners)
+
+WebSocket and secure WebSocket listeners have options that control how EMQX determines a client's source address when the listener sits behind a proxy or load balancer:
+
+- `websocket.proxy_address_header` (default: `x-forwarded-for`)
+- `websocket.proxy_port_header` (default: `x-forwarded-port`)
+- `websocket.proxy_address_allow` (default: `["0.0.0.0/0"]`, since 6.3.0)
+
+When the header configured by `proxy_address_header` is present on the WebSocket upgrade request, EMQX uses the first (leftmost) entry of the header value as the client's source IP address (or port, for `proxy_port_header`) instead of the address of the real TCP peer. The derived address is what IP-based authorization rules, banned clients, flapping detection, and audit and trace logs see as the client's source IP.
+
+`proxy_address_allow` restricts which TCP peers (proxies) are trusted to set these headers: the headers are honored only when the real TCP peer address falls within one of the listed CIDR ranges. The default `["0.0.0.0/0"]` trusts every IPv4 peer, matching the behavior of releases before 6.3.0; IPv6 peers are not trusted by default. Set it to the addresses of your proxies to trust only them, or to `[]` to never honor the headers.
+
+::: warning Trust the forwarded address header only behind a trusted proxy
+
+The header value determines the client's apparent source IP, so it must be honored only when a trusted proxy sets it:
+
+- If the listener is directly reachable by clients (no proxy in front), any client can send the header and choose its own apparent source IP. Set `proxy_address_allow = []` to never honor the headers. On releases before 6.3.0, set `proxy_address_header = ""` and `proxy_port_header = ""` instead.
+- If there is a proxy but it **appends** its observation to an inbound `X-Forwarded-For` header instead of overwriting or stripping it (appending is the default behavior of most proxies, for example NGINX's `$proxy_add_x_forwarded_for`), the leftmost entry that EMQX reads is still the one supplied by the client, so the source IP can still be spoofed — even when the proxy is in `proxy_address_allow`. Configure the proxy to overwrite the header with the address it observed, or use the [PROXY protocol](../deploy/cluster/lb.md) instead.
+- Do not try to disable the mechanism by pointing `proxy_address_header` at an unused header name: a client can send a header by any name. Use `proxy_address_allow = []` (or the empty string for the header options) instead.
+
+When `proxy_protocol = true` is set on the listener, the client address comes from the PROXY protocol handshake, and these headers are not consulted.
+:::
+
 <!--To add QUIC-->
 
 <!--To add code sample for adding multiple listeners.-->

--- a/zh_CN/configuration/listener.md
+++ b/zh_CN/configuration/listener.md
@@ -133,6 +133,29 @@ listeners.wss.default {
 - `websocket.mqtt_path` 设置 WebSocket 的 MQTT 协议路径，默认为 `/mqtt`。
 - `ssl_options` 包括 SSL/TLS 配置选项，详细说明参见 [配置 SSL 监听器](#配置-ssl-监听器)。
 
+## WebSocket 监听器的转发客户端地址
+
+WebSocket 与安全 WebSocket 监听器提供以下配置项，用于在监听器位于代理或负载均衡器之后时决定 EMQX 如何获取客户端的源地址：
+
+- `websocket.proxy_address_header`（默认值：`x-forwarded-for`）
+- `websocket.proxy_port_header`（默认值：`x-forwarded-port`）
+- `websocket.proxy_address_allow`（默认值：`["0.0.0.0/0"]`，6.3.0 起提供）
+
+当 WebSocket 升级请求中携带 `proxy_address_header` 所配置的请求头时，EMQX 会使用该请求头值中第一个（最左侧的）条目作为客户端的源 IP 地址（`proxy_port_header` 对应端口），而不再使用真实 TCP 对端的地址。基于 IP 的授权规则、客户端封禁、连接抖动检测以及审计与追踪日志所看到的客户端源 IP 都来自这个派生地址。
+
+`proxy_address_allow` 限制哪些 TCP 对端（代理）有权通过这些请求头设置客户端地址：只有当真实 TCP 对端地址落在所列 CIDR 范围内时，请求头才会被采信。默认值 `["0.0.0.0/0"]` 信任所有 IPv4 对端，与 6.3.0 之前版本的行为一致；IPv6 对端默认不被信任。可将其设置为您的代理地址以仅信任这些代理，或设置为 `[]` 以完全不采信请求头。
+
+::: warning 仅在受信任代理之后才可信任转发地址请求头
+
+该请求头的值决定了客户端的表观源 IP，因此只有在由受信任的代理设置该请求头时才可信任它：
+
+- 如果监听器可被客户端直接访问（前面没有代理），任何客户端都可以自行发送该请求头，从而任意选择自己的表观源 IP。此时应设置 `proxy_address_allow = []` 以完全不采信请求头；在 6.3.0 之前的版本中，应设置 `proxy_address_header = ""` 和 `proxy_port_header = ""`。
+- 如果前面有代理，但代理是将自身观察到的地址**追加**到入站 `X-Forwarded-For` 请求头之后，而不是覆盖或去除它（大多数代理默认为追加行为，例如 NGINX 的 `$proxy_add_x_forwarded_for`），那么 EMQX 读取的最左侧条目仍然是客户端提供的值——即使该代理在 `proxy_address_allow` 中，源 IP 依然可以被伪造。应将代理配置为使用其观察到的地址覆盖该请求头，或改用 [Proxy Protocol](../deploy/cluster/lb.md)。
+- 不要试图通过将 `proxy_address_header` 指向一个未使用的请求头名称来“禁用”该机制：客户端可以发送任意名称的请求头。请改用 `proxy_address_allow = []`（或将请求头配置项设置为空字符串）。
+
+当监听器设置了 `proxy_protocol = true` 时，客户端地址来自 Proxy Protocol 握手，不会读取这些请求头。
+:::
+
 ## 将监听器关联到配置区域
 
 EMQX 中的每个监听器都与一个区域相关联，默认设置为名为 `default` 的逻辑区域。


### PR DESCRIPTION
## What

Release-6.3 variant of #3740 / #3741: documents the WebSocket forwarded-address headers (`websocket.proxy_address_header` / `websocket.proxy_port_header`) in `configuration/listener.md`, with a security note on when the header must not be trusted — and presents the new 6.3.0 option `websocket.proxy_address_allow` (CIDR allow-list of trusted proxy sources, default `["0.0.0.0/0"]`, `[]` = never honor the headers) as the primary control.

zh_CN updated in lockstep with en_US.

## Note

**Draft until the corresponding EMQX feature PR (emqx.git branch `260805-ws-proxy-address-allow`, base `dev-63`) is merged** — the `proxy_address_allow` semantics documented here (leftmost-entry parsing unchanged, IPv4-only default trust, `[]` as explicit off switch) should be re-checked against the final implementation before undrafting.

The security-checklist item and NGINX guide tip from #3741 are not duplicated here; they will arrive on this branch via the regular 6.0 → 6.1 → 6.2 → 6.3 sync merges (the listener.md section added here will conflict with the synced 6.0 version — resolve in favor of this branch's 6.3 variant).