### PR TITLE
docs: align HOCON configuration examples

### DIFF
--- a/en_US/develop/data-integration/data-bridges.md
+++ b/en_US/develop/data-integration/data-bridges.md
@@ -221,7 +221,7 @@ actions {
         {kind = reference, type = mqtt, name = fallback},
         {
           kind = republish,
-          args = {
+          args {
             topic = "fallback/republish/topic"
             qos = 1
             payload = "${payload}"

--- a/en_US/develop/data-integration/message-transformation.md
+++ b/en_US/develop/data-integration/message-transformation.md
@@ -90,8 +90,13 @@ message_transformation {
       name = mytransformation
       topics = ["t"]
       failure_action = drop
-      payload_decoder = {type = avro, schema = myschema}
-      payload_encoder = {type = json}
+      payload_decoder {
+        type = avro
+        schema = myschema
+      }
+      payload_encoder {
+        type = json
+      }
       operations = [
         {key = "topic", value = "concat([client_attrs.tenant, '/', topic])"}
       ]

--- a/en_US/develop/data-integration/rule-configs.md
+++ b/en_US/develop/data-integration/rule-configs.md
@@ -33,7 +33,7 @@ rule_engine {
             },
             {
                 function = republish
-                args = {
+                args {
                     topic = "a/1"
                     payload = "${payload}"
                 }
@@ -72,7 +72,7 @@ Before using data bridge, you need to create it in advance:
 
 ```js
 bridges.mqtt.my_egress_mqtt_bridge {
-    connector = {
+    connector {
         server = "broker.EMQX.io:1883"
         username = "username1"
         password = ""
@@ -112,7 +112,7 @@ rule_engine {
         actions = [
             {
                 function = republish
-                args = {
+                args {
                     topic = "t/b"
                     qos = "${qos}"
                     payload = "y: ${y}"
@@ -176,7 +176,7 @@ This MQTT bridge needs to be created in advance:
 
 ```js
 bridges.mqtt.my_mqtt_source {
-    connector = {
+    connector {
         server = "192.168.2.100:1883"
         username = "username1"
         password = ""

--- a/en_US/develop/file-transfer/broker.md
+++ b/en_US/develop/file-transfer/broker.md
@@ -41,18 +41,22 @@ file_transfer {
   enable = true
 
   # Segment storage configuration
-  storage.local.segments = {
-    # Segment storage directory, preferably set on high I/O performance disks.
-    root = "./data/file_transfer/segments"
+  storage {
+    local {
+      segments {
+        # Segment storage directory, preferably set on high I/O performance disks.
+        root = "./data/file_transfer/segments"
 
-    # Scheduled cleaning of expired segment files
-    gc {
-      # Cleaning interval
-      interval = "1h"
+        # Scheduled cleaning of expired segment files
+        gc {
+          # Cleaning interval
+          interval = "1h"
 
-      # Maximum valid period for segment storage, segments will be cleared after this period, even if they have not been merged.
-      # The validity period specified by the client must not exceed this value.
-      maximum_segments_ttl = "24h"
+          # Maximum valid period for segment storage, segments will be cleared after this period, even if they have not been merged.
+          # The validity period specified by the client must not exceed this value.
+          maximum_segments_ttl = "24h"
+        }
+      }
     }
   }
 }

--- a/en_US/guides/access-control/authn/authn.md
+++ b/en_US/guides/access-control/authn/authn.md
@@ -319,7 +319,7 @@ listeners.tcp.default {
 gateway.stomp {
   ...
   # Specific global authenticator for all STOMP listeners
-  authentication = {
+  authentication {
     ...
   }
 

--- a/en_US/guides/api.md
+++ b/en_US/guides/api.md
@@ -51,7 +51,7 @@ You can manually create API keys for authentication on the Dashboard by navigati
 You can also create API keys using the bootstrap file method. Add the following configuration to the `emqx.conf` file to specify the file location:
 
 ```bash
-api_key = {
+api_key {
   bootstrap_file = "etc/default_api_key.conf"
 }
 ```

--- a/en_US/guides/configuration/dashboard.md
+++ b/en_US/guides/configuration/dashboard.md
@@ -42,9 +42,9 @@ dashboard {
   unsuccessful_login_max_attempts = 5
   unsuccessful_login_lock_duration = 10m
   unsuccessful_login_interval = 5m
-  sso = {
+  sso {
     # Normally, only one of `ldap`, `oidc`, or `smal` can be active at a time. Below is for the demonstration purposes.
-    ldap = {
+    ldap {
       enable = true
       backend = "ldap"
       query_timeout = "5s"
@@ -56,7 +56,7 @@ dashboard {
       filter = "(& (objectClass=person) (uid=${username}))"
       request_timeout = "10s"
     }
-    oidc = {
+    oidc {
       enable = true
       backend = oidc
       issuer = "https://issuer.example.com"
@@ -79,7 +79,7 @@ dashboard {
         "RS256"
       ]
     }
-    saml = {
+    saml {
       enable = true
       backend = "saml"
       dashboard_addr = "https://127.0.0.1:18083"

--- a/en_US/guides/multi-factor-authn/multi-factor-authentication.md
+++ b/en_US/guides/multi-factor-authn/multi-factor-authentication.md
@@ -38,7 +38,11 @@ To enable MFA for all Dashboard users by default, the administrator needs to con
 Example configuration:
 
 ```bash
-dashboard.default_mfa = {mechanism: totp}
+dashboard {
+  default_mfa {
+    mechanism = totp
+  }
+}
 ```
 
 ### Enable MFA for Users via EMQX Dashboard

--- a/ja_JP/develop/data-integration/data-bridges.md
+++ b/ja_JP/develop/data-integration/data-bridges.md
@@ -218,7 +218,7 @@ actions {
         {kind = reference, type = mqtt, name = fallback},
         {
           kind = republish,
-          args = {
+          args {
             topic = "fallback/republish/topic"
             qos = 1
             payload = "${payload}"

--- a/ja_JP/develop/data-integration/message-transformation.md
+++ b/ja_JP/develop/data-integration/message-transformation.md
@@ -92,8 +92,13 @@ message_transformation {
       name = mytransformation
       topics = ["t"]
       failure_action = drop
-      payload_decoder = {type = avro, schema = myschema}
-      payload_encoder = {type = json}
+      payload_decoder {
+        type = avro
+        schema = myschema
+      }
+      payload_encoder {
+        type = json
+      }
       operations = [
         {key = "topic", value = "concat([client_attrs.tenant, '/', topic])"}
       ]

--- a/ja_JP/develop/file-transfer/broker.md
+++ b/ja_JP/develop/file-transfer/broker.md
@@ -41,18 +41,22 @@ file_transfer {
   enable = true
 
   # セグメント保存の設定
-  storage.local.segments = {
-    # セグメント保存ディレクトリ。I/O性能の高いディスクに設定することが望ましい。
-    root = "./data/file_transfer/segments"
+  storage {
+    local {
+      segments {
+        # セグメント保存ディレクトリ。I/O性能の高いディスクに設定することが望ましい。
+        root = "./data/file_transfer/segments"
 
-    # 有効期限切れセグメントの定期クリーンアップ設定
-    gc {
-      # クリーンアップ間隔
-      interval = "1h"
+        # 有効期限切れセグメントの定期クリーンアップ設定
+        gc {
+          # クリーンアップ間隔
+          interval = "1h"
 
-      # セグメント保存の最大有効期間。この期間を過ぎるとマージされていなくてもセグメントは削除される。
-      # クライアントが指定する有効期間はこの値を超えてはならない。
-      maximum_segments_ttl = "24h"
+          # セグメント保存の最大有効期間。この期間を過ぎるとマージされていなくてもセグメントは削除される。
+          # クライアントが指定する有効期間はこの値を超えてはならない。
+          maximum_segments_ttl = "24h"
+        }
+      }
     }
   }
 }

--- a/ja_JP/guides/access-control/authn/authn.md
+++ b/ja_JP/guides/access-control/authn/authn.md
@@ -315,7 +315,7 @@ listeners.tcp.default {
 gateway.stomp {
   ...
   # すべてのSTOMPリスナーに対するグローバル認証機
-  authentication = {
+  authentication {
     ...
   }
 

--- a/ja_JP/guides/api.md
+++ b/ja_JP/guides/api.md
@@ -264,7 +264,7 @@ POST http://your-emqx-address:8483/api/v5/login
 ブートストラップファイル方式でもAPIキーを作成可能です。以下の設定ファイルでファイルの場所を指定します。
 
 ```bash
-api_key = {
+api_key {
   bootstrap_file = "etc/default_api_key.conf"
 }
 ```

--- a/ja_JP/guides/configuration/dashboard.md
+++ b/ja_JP/guides/configuration/dashboard.md
@@ -42,9 +42,9 @@ dashboard {
   unsuccessful_login_max_attempts = 5
   unsuccessful_login_lock_duration = 10m
   unsuccessful_login_interval = 5m
-  sso = {
+  sso {
     # 通常、`ldap`、`oidc`、`saml`のうち一つだけが有効になります。以下はデモ用の設定です。
-    ldap = {
+    ldap {
       enable = true
       backend = "ldap"
       query_timeout = "5s"
@@ -56,7 +56,7 @@ dashboard {
       filter = "(& (objectClass=person) (uid=${username}))"
       request_timeout = "10s"
     }
-    oidc = {
+    oidc {
       enable = true
       backend = oidc
       issuer = "https://issuer.example.com"
@@ -79,7 +79,7 @@ dashboard {
         "RS256"
       ]
     }
-    saml = {
+    saml {
       enable = true
       backend = "saml"
       dashboard_addr = "https://127.0.0.1:18083"

--- a/ja_JP/guides/multi-factor-authn/multi-factor-authentication.md
+++ b/ja_JP/guides/multi-factor-authn/multi-factor-authentication.md
@@ -38,7 +38,11 @@ MFAはデフォルトで無効になっています。ユーザーにMFAを有�
 設定例：
 
 ```bash
-dashboard.default_mfa = {mechanism: totp}
+dashboard {
+  default_mfa {
+    mechanism = totp
+  }
+}
 ```
 
 ### EMQXダッシュボードからユーザーごとにMFAを有効化する

--- a/zh_CN/develop/data-integration/data-bridges.md
+++ b/zh_CN/develop/data-integration/data-bridges.md
@@ -216,7 +216,7 @@ actions {
         {kind = reference, type = mqtt, name = fallback},
         {
           kind = republish,
-          args = {
+          args {
             topic = "fallback/republish/topic"
             qos = 1
             payload = "${payload}"

--- a/zh_CN/develop/data-integration/message-transformation.md
+++ b/zh_CN/develop/data-integration/message-transformation.md
@@ -89,8 +89,13 @@ message_transformation {
       name = mytransformation
       topics = ["t"]
       failure_action = drop
-      payload_decoder = {type = avro, schema = myschema}
-      payload_encoder = {type = json}
+      payload_decoder {
+        type = avro
+        schema = myschema
+      }
+      payload_encoder {
+        type = json
+      }
       operations = [
         {key = "topic", value = "concat([client_attrs.tenant, '/', topic])"}
       ]

--- a/zh_CN/develop/data-integration/rule-configs.md
+++ b/zh_CN/develop/data-integration/rule-configs.md
@@ -32,7 +32,7 @@ rule_engine {
             },
             {
                 function = republish
-                args = {
+                args {
                     topic = "a/1"
                     payload = "${payload}"
                 }
@@ -71,7 +71,7 @@ rule_engine {
 
 ```js
 bridges.mqtt.my_egress_mqtt_bridge {
-    connector = {
+    connector {
         server = "broker.emqx.io:1883"
         username = "username1"
         password = ""
@@ -110,7 +110,7 @@ rule_engine {
         actions = [
             {
                 function = republish
-                args = {
+                args {
                     topic = "t/b"
                     qos = "${qos}"
                     payload = "y: ${y}"
@@ -172,7 +172,7 @@ SQL 语句里指定了一个 Sink 主题：`$bridges/mqtt:my_mqtt_source`，
 
 ```js
 bridges.mqtt.my_mqtt_source {
-    connector = {
+    connector {
         server = "192.168.2.100:1883"
         username = "username1"
         password = ""

--- a/zh_CN/develop/file-transfer/broker.md
+++ b/zh_CN/develop/file-transfer/broker.md
@@ -41,18 +41,22 @@ file_transfer {
   enable = true
 
   # 分片存储配置
-  storage.local.segments = {
-    # 分片存储目录，建议优先设置到高 I/O 性能的磁盘上。
-    root = "./data/file_transfer/segments"
+  storage {
+    local {
+      segments {
+        # 分片存储目录，建议优先设置到高 I/O 性能的磁盘上。
+        root = "./data/file_transfer/segments"
 
-    # 定时清理已过期的分片文件
-    gc {
-      # 清理间隔
-      interval = "1h"
+        # 定时清理已过期的分片文件
+        gc {
+          # 清理间隔
+          interval = "1h"
 
-      # 分片存储最大有效期，达到有效期之后，即使分片未被合并也将被清除。
-      # 客户端指定的有效期不得超过此值。
-      maximum_segments_ttl = "24h"
+          # 分片存储最大有效期，达到有效期之后，即使分片未被合并也将被清除。
+          # 客户端指定的有效期不得超过此值。
+          maximum_segments_ttl = "24h"
+        }
+      }
     }
   }
 }

--- a/zh_CN/guides/access-control/authn/authn.md
+++ b/zh_CN/guides/access-control/authn/authn.md
@@ -305,7 +305,7 @@ gateway.stomp {
   ...
   enable_authn = true
   # Specific global authenticator for all STOMP listeners
-  authentication = {
+  authentication {
     ...
   }
 

--- a/zh_CN/guides/api.md
+++ b/zh_CN/guides/api.md
@@ -260,7 +260,7 @@ POST http://your-emqx-address:8483/api/v5/login
 您也可以通过 bootstrap 文件的方式创建 API 密钥。在 `base.hocon` 配置文件中添加以下配置，指定文件位置：
 
 ```bash
-api_key = {
+api_key {
   bootstrap_file = "etc/default_api_key.conf"
 }
 ```

--- a/zh_CN/guides/configuration/dashboard.md
+++ b/zh_CN/guides/configuration/dashboard.md
@@ -41,9 +41,9 @@ dashboard {
   unsuccessful_login_max_attempts = 5
   unsuccessful_login_lock_duration = 10m
   unsuccessful_login_interval = 5m
-  sso = {
+  sso {
     # Normally, only one of `ldap`, `oidc`, or `smal` can be active at a time. Below is for the demonstration purposes.
-    ldap = {
+    ldap {
       enable = true
       backend = "ldap"
       query_timeout = "5s"
@@ -55,7 +55,7 @@ dashboard {
       filter = "(& (objectClass=person) (uid=${username}))"
       request_timeout = "10s"
     }
-    oidc = {
+    oidc {
       enable = true
       backend = oidc
       issuer = "https://issuer.example.com"
@@ -78,7 +78,7 @@ dashboard {
         "RS256"
       ]
     }
-    saml = {
+    saml {
       enable = true
       backend = "saml"
       dashboard_addr = "https://127.0.0.1:18083"

--- a/zh_CN/guides/multi-factor-authn/multi-factor-authentication.md
+++ b/zh_CN/guides/multi-factor-authn/multi-factor-authentication.md
@@ -36,7 +36,11 @@ MFA 默认为禁用状态。要为用户启用 MFA，管理员必须配置系统
 示例配置：
 
 ```bash
-dashboard.default_mfa = {mechanism: totp}
+dashboard {
+  default_mfa {
+    mechanism = totp
+  }
+}
 ```
 
 ### 通过 EMQX Dashboard 启用 MFA


### PR DESCRIPTION
## Summary

- Align HOCON configuration examples with the block-style format used by EMQX.
- Apply the same format consistently across the English, Chinese, and Japanese documentation.
- Reduce confusion when documentation examples are compared with the actual configuration syntax.