### PR TITLE
docs: point plugin download links at the emqx.com CDN and add sha256 (release-6.0)

### DIFF
--- a/en_US/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
+++ b/en_US/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
@@ -70,6 +70,6 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) |
+| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/guides/extensions/plugin-catalog/6.0/emqx-relup.md
+++ b/en_US/guides/extensions/plugin-catalog/6.0/emqx-relup.md
@@ -109,6 +109,6 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) |
+| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
+++ b/en_US/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
@@ -215,6 +215,6 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) |
+| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
+++ b/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
@@ -66,10 +66,10 @@ emqx ctl backup_sync status
 
 ## ダウンロード
 
-各EMQXリリースのtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) |
+| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-relup.md
+++ b/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-relup.md
@@ -105,10 +105,10 @@ emqx ctl relup logs-clear     # このノードのログ行をすべて削除
 
 ## ダウンロード
 
-各EMQXリリース用のtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) |
+| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
+++ b/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
@@ -209,10 +209,10 @@ APIクライアントへのガイダンス：
 
 ## ダウンロード
 
-各EMQXリリースのタールボール：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) |
+| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/refresh-plugin-download-links.py
+++ b/refresh-plugin-download-links.py
@@ -4,12 +4,15 @@
 Starting with EMQX 5.10 (enterprise) and 6.2 (unified), plugins live in
 the emqx.git monorepo under `plugins/<name>/` and each has a `VERSION`
 file. For every stable release tag in the chosen series, the CI
-publishes a tarball at:
+publishes a tarball and its sha256 digest, served from the emqx.com
+download CDN:
 
-    https://packages.emqx.io/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.sha256
 
 where `<tag>` is the literal git tag — bare semver for 6.x (e.g. `6.2.0`)
-and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`).
+and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`). Note the digest
+file replaces the `.tar.gz` extension rather than appending to it.
 
 This script walks the stable tags of one series (e.g. 5.10 or 6.2),
 reads each plugin's VERSION file, and regenerates a "Download" table
@@ -51,8 +54,14 @@ from pathlib import Path
 from typing import Iterable
 
 DEFAULT_EMQX_REMOTE = "https://github.com/emqx/emqx.git"
+# The emqx.com download CDN (matches scripts/rel/print-download-links.py in
+# emqx.git). Steering users to www.emqx.com/downloads rather than the S3
+# bucket keeps download statistics visible.
 PACKAGE_URL_TEMPLATE = (
-    "https://packages.emqx.io/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+)
+SHA256_URL_TEMPLATE = (
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.sha256"
 )
 
 # Stable release tags. Two conventions are in use:
@@ -90,7 +99,7 @@ LOCALES: dict[str, dict[str, str]] = {
     },
 }
 
-CATALOG_BASE = Path("extensions/plugin-catalog")
+CATALOG_BASE = Path("guides/extensions/plugin-catalog")
 
 
 def catalog_subpath(series: tuple[int, int]) -> Path:
@@ -261,9 +270,13 @@ def render_section(
         url = PACKAGE_URL_TEMPLATE.format(
             tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
         )
+        sha256_url = SHA256_URL_TEMPLATE.format(
+            tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
+        )
         filename = f"{plugin}-{plugin_ver}.tar.gz"
         lines.append(
-            f"| {tag.display_version} | {plugin_ver} | [{filename}]({url}) |"
+            f"| {tag.display_version} | {plugin_ver} | "
+            f"[{filename}]({url}) ([sha256]({sha256_url})) |"
         )
     lines.append("")
     lines.append(END_MARKER)

--- a/refresh-plugin-download-links.py
+++ b/refresh-plugin-download-links.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Refresh plugin download-link tables in plugin-catalog docs.
 
-Starting with EMQX 5.10 (enterprise) and 6.2 (unified), plugins live in
+Starting with EMQX 5.10 (enterprise) and 6.0.3 (unified), plugins live in
 the emqx.git monorepo under `plugins/<name>/` and each has a `VERSION`
 file. For every stable release tag in the chosen series, the CI
 publishes a tarball and its sha256 digest, served from the emqx.com

--- a/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
+++ b/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-backup-sync.md
@@ -70,6 +70,6 @@ emqx ctl backup_sync status
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) |
+| 6.0.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_backup_sync-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-relup.md
+++ b/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-relup.md
@@ -109,6 +109,6 @@ emqx ctl relup logs-clear     # 清除本节点上的所有日志
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) |
+| 6.0.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_relup-1.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
+++ b/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-username-quota.md
@@ -216,6 +216,6 @@ API 客户端指南：
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) |
+| 6.0.3 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.0.3/emqx_username_quota-1.2.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->


### PR DESCRIPTION
Port of #3814 to release-6.0. Align the plugin download-link generator with `scripts/rel/print-download-links.py` in emqx.git:

- Serve plugin packages from the emqx.com download CDN (`https://www.emqx.com/downloads/emqx-plugins/...`) instead of the S3 bucket (`https://packages.emqx.io/...`), keeping download statistics visible.
- Add a `sha256` link next to each tarball. The digest file replaces the `.tar.gz` extension (`<name>-<vsn>.sha256`).
- Fix the catalog base path after the directory restructuring (`<locale>/guides/extensions/plugin-catalog`).

Regenerated the download tables for the 6.0 series in all three locales; all URL forms verified to return HTTP 200 after the CDN redirect.