### PR TITLE
docs: point plugin download links at the emqx.com CDN and add sha256 (release-6.1)

### DIFF
--- a/en_US/extensions/plugin-catalog/6.1/emqx-acme.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-acme.md
@@ -152,8 +152,8 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) |
-| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) |
-| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) |
+| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.sha256)) |
+| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.sha256)) |
+| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-backup-sync.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-backup-sync.md
@@ -70,7 +70,7 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) |
-| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) |
+| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.sha256)) |
+| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
@@ -597,8 +597,8 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
+| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-maptabs.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-maptabs.md
@@ -103,6 +103,6 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.5 | 0.1.1 | [emqx_maptabs-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.5/emqx_maptabs-0.1.1.tar.gz) |
+| 6.1.5 | 0.1.2 | [emqx_maptabs-0.1.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-offline-messages.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-offline-messages.md
@@ -80,8 +80,8 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) |
+| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-relup.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-relup.md
@@ -109,8 +109,8 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) |
-| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) |
-| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) |
+| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.sha256)) |
+| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.sha256)) |
+| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-sync-request.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-sync-request.md
@@ -192,6 +192,6 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) |
+| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-unsgov.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-unsgov.md
@@ -245,8 +245,8 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) |
+| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/6.1/emqx-username-quota.md
+++ b/en_US/extensions/plugin-catalog/6.1/emqx-username-quota.md
@@ -215,9 +215,9 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) |
-| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) |
-| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) |
-| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) |
+| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.sha256)) |
+| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.sha256)) |
+| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.sha256)) |
+| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-acme.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-acme.md
@@ -148,12 +148,12 @@ ACME CA は常に検証対象ドメインのポート 80 に対して HTTP-01 �
 
 ## ダウンロード
 
-各 EMQX リリース向けの tarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
 | EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) |
-| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) |
-| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) |
+| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.sha256)) |
+| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.sha256)) |
+| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-backup-sync.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-backup-sync.md
@@ -66,11 +66,11 @@ emqx ctl backup_sync status
 
 ## ダウンロード
 
-各EMQXリリースのタールボール：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) |
-| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) |
+| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.sha256)) |
+| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
@@ -509,12 +509,12 @@ QoS 0 のリモートブローカーへのパブリッシュは、メッセー�
 
 ## ダウンロード
 
-各 EMQX リリース向けの tarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
 | EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
+| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-maptabs.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-maptabs.md
@@ -99,10 +99,10 @@ maptab_lookup('signals', concat(client_attrs.tns, ':', item_id))
 
 ## ダウンロード
 
-各EMQXリリース向けのtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.5 | 0.1.1 | [emqx_maptabs-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.5/emqx_maptabs-0.1.1.tar.gz) |
+| 6.1.5 | 0.1.2 | [emqx_maptabs-0.1.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-offline-messages.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-offline-messages.md
@@ -76,12 +76,12 @@ Redisは `mqtt:sub:*` および `mqtt:msg:*` キースペースの下でハッ�
 
 ## ダウンロード
 
-各EMQXリリース用のtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) |
+| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-relup.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-relup.md
@@ -105,12 +105,12 @@ emqx ctl relup logs-clear     # このノードのログ行をすべて削除
 
 ## ダウンロード
 
-各EMQXリリース用のtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) |
-| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) |
-| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) |
+| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.sha256)) |
+| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.sha256)) |
+| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-sync-request.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-sync-request.md
@@ -188,10 +188,10 @@ sync_request.pending_responses: 0
 
 ## ダウンロード
 
-各EMQXリリース用のtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) |
+| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-unsgov.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-unsgov.md
@@ -221,12 +221,12 @@ UNS Governanceはトピック構造と（オプションで）ペイロードス
 
 ## ダウンロード
 
-各EMQXリリースのタールボール：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) |
+| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/ja_JP/extensions/plugin-catalog/6.1/emqx-username-quota.md
+++ b/ja_JP/extensions/plugin-catalog/6.1/emqx-username-quota.md
@@ -211,13 +211,13 @@ APIクライアントへの推奨：
 
 ## ダウンロード
 
-各EMQXリリースのtarball：
+各 EMQX リリースに対応するプラグインパッケージ:
 
-| EMQXバージョン | プラグインバージョン | パッケージ |
+| EMQX バージョン | プラグインバージョン | パッケージ |
 |---|---|---|
-| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) |
-| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) |
-| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) |
-| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) |
+| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.sha256)) |
+| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.sha256)) |
+| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.sha256)) |
+| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/refresh-plugin-download-links.py
+++ b/refresh-plugin-download-links.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """Refresh plugin download-link tables in plugin-catalog docs.
 
-Starting with EMQX 5.10 (enterprise) and 6.2 (unified), plugins live in
+Starting with EMQX 5.10 (enterprise) and 6.0.3 (unified), plugins live in
 the emqx.git monorepo under `plugins/<name>/` and each has a `VERSION`
 file. For every stable release tag in the chosen series, the CI
-publishes a tarball at:
+publishes a tarball and its sha256 digest, served from the emqx.com
+download CDN:
 
-    https://packages.emqx.io/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.sha256
 
 where `<tag>` is the literal git tag — bare semver for 6.x (e.g. `6.2.0`)
-and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`).
+and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`). Note the digest
+file replaces the `.tar.gz` extension rather than appending to it.
 
 This script walks the stable tags of one series (e.g. 5.10 or 6.2),
 reads each plugin's VERSION file, and regenerates a "Download" table
@@ -61,8 +64,14 @@ from pathlib import Path
 from typing import Iterable
 
 DEFAULT_EMQX_REMOTE = "https://github.com/emqx/emqx.git"
+# The emqx.com download CDN (matches scripts/rel/print-download-links.py in
+# emqx.git). Steering users to www.emqx.com/downloads rather than the S3
+# bucket keeps download statistics visible.
 PACKAGE_URL_TEMPLATE = (
-    "https://packages.emqx.io/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+)
+SHA256_URL_TEMPLATE = (
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.sha256"
 )
 
 # Stable release tags. Two conventions are in use:
@@ -303,9 +312,13 @@ def render_section(
         url = PACKAGE_URL_TEMPLATE.format(
             tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
         )
+        sha256_url = SHA256_URL_TEMPLATE.format(
+            tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
+        )
         filename = f"{plugin}-{plugin_ver}.tar.gz"
         lines.append(
-            f"| {tag.display_version} | {plugin_ver} | [{filename}]({url}) |"
+            f"| {tag.display_version} | {plugin_ver} | "
+            f"[{filename}]({url}) ([sha256]({sha256_url})) |"
         )
     lines.append("")
     lines.append(END_MARKER)

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-acme.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-acme.md
@@ -152,8 +152,8 @@ ACME CA 始终通过被验证域名的 80 端口执行 HTTP-01 挑战。此行�
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) |
-| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) |
-| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) |
+| 6.1.2 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_acme-0.2.0.sha256)) |
+| 6.1.3 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_acme-0.2.0.sha256)) |
+| 6.1.4 | 0.2.0 | [emqx_acme-0.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_acme-0.2.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-backup-sync.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-backup-sync.md
@@ -70,7 +70,7 @@ emqx ctl backup_sync status
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) |
-| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) |
+| 6.1.3 | 0.1.0 | [emqx_backup_sync-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_backup_sync-0.1.0.sha256)) |
+| 6.1.4 | 0.1.1 | [emqx_backup_sync-0.1.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_backup_sync-0.1.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-bridge-mqtt-dq.md
@@ -561,8 +561,8 @@ curl -u admin:public \
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
-| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
+| 6.1.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.1.4 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-maptabs.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-maptabs.md
@@ -103,6 +103,6 @@ maptab_lookup('signals', concat(client_attrs.tns, ':', item_id))
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.5 | 0.1.1 | [emqx_maptabs-0.1.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.5/emqx_maptabs-0.1.1.tar.gz) |
+| 6.1.5 | 0.1.2 | [emqx_maptabs-0.1.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.5/emqx_maptabs-0.1.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-offline-messages.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-offline-messages.md
@@ -80,8 +80,8 @@ Redis 在 `mqtt:sub:*` 和 `mqtt:msg:*` 键空间下使用哈希（hash）和有
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) |
-| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) |
+| 6.1.2 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.3 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_offline_messages-2.0.0.sha256)) |
+| 6.1.4 | 2.0.0 | [emqx_offline_messages-2.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_offline_messages-2.0.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-relup.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-relup.md
@@ -109,8 +109,8 @@ emqx ctl relup logs-clear     # 清除本节点上的所有日志
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) |
-| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) |
-| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) |
+| 6.1.2 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_relup-1.0.0.sha256)) |
+| 6.1.3 | 1.0.0 | [emqx_relup-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_relup-1.0.0.sha256)) |
+| 6.1.4 | 1.0.1 | [emqx_relup-1.0.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_relup-1.0.1.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-sync-request.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-sync-request.md
@@ -192,6 +192,6 @@ sync_request.pending_responses: 0
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) |
+| 6.1.4 | 0.1.0 | [emqx_sync_request-0.1.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_sync_request-0.1.0.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-unsgov.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-unsgov.md
@@ -243,8 +243,8 @@ UNS 治理会同时校验主题结构以及（可选的）载荷 schema。
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) |
-| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) |
+| 6.1.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.3 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_unsgov-0.1.3.sha256)) |
+| 6.1.4 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_unsgov-0.1.3.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/6.1/emqx-username-quota.md
+++ b/zh_CN/extensions/plugin-catalog/6.1/emqx-username-quota.md
@@ -216,9 +216,9 @@ API 客户端指南：
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) |
-| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) |
-| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) |
-| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) |
+| 6.1.1 | 1.0.0 | [emqx_username_quota-1.0.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.1/emqx_username_quota-1.0.0.sha256)) |
+| 6.1.2 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.2/emqx_username_quota-1.2.1.sha256)) |
+| 6.1.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.3/emqx_username_quota-1.2.2.sha256)) |
+| 6.1.4 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.1.4/emqx_username_quota-1.2.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->


### PR DESCRIPTION
Port of #3814 to release-6.1. Align the plugin download-link generator with `scripts/rel/print-download-links.py` in emqx.git:

- Serve plugin packages from the emqx.com download CDN (`https://www.emqx.com/downloads/emqx-plugins/...`) instead of the S3 bucket (`https://packages.emqx.io/...`), keeping download statistics visible.
- Add a `sha256` link next to each tarball. The digest file replaces the `.tar.gz` extension (`<name>-<vsn>.sha256`).

Regenerated the 6.1 download tables in all three locales with `--upcoming 6.1.5:release-61`, which also picks up the `emqx_maptabs` version bump to 0.1.2.

All CDN URLs verified to return HTTP 200 after the redirect, with two exceptions:
- `6.1.5/*` links resolve when 6.1.5 is released (docs published ahead, same as before).
- `6.1.1/emqx_username_quota-1.0.0.sha256` is missing from the bucket (the tarball is there; digests exist from 6.1.2 onward). Needs a one-off backfill upload.