### PR TITLE
docs: point plugin download links at the emqx.com CDN and add sha256 (release-6.2)

### DIFF
--- a/en_US/extensions/plugin-catalog/emqx-bridge-mqtt-dq.md
+++ b/en_US/extensions/plugin-catalog/emqx-bridge-mqtt-dq.md
@@ -597,7 +597,9 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.2.0 | 0.5.1 | [emqx_bridge_mqtt_dq-0.5.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.tar.gz) |
-| 6.2.1 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
+| 6.2.0 | 0.5.1 | [emqx_bridge_mqtt_dq-0.5.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.sha256)) |
+| 6.2.1 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.2.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.2.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/emqx-unsgov.md
+++ b/en_US/extensions/plugin-catalog/emqx-unsgov.md
@@ -244,7 +244,9 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.2.0 | 0.1.2 | [emqx_unsgov-0.1.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.tar.gz) |
-| 6.2.1 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.tar.gz) |
+| 6.2.0 | 0.1.2 | [emqx_unsgov-0.1.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.sha256)) |
+| 6.2.1 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.sha256)) |
+| 6.2.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_unsgov-0.1.3.sha256)) |
+| 6.2.3 | 0.1.4 | [emqx_unsgov-0.1.4.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_unsgov-0.1.4.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_unsgov-0.1.4.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/en_US/extensions/plugin-catalog/emqx-username-quota.md
+++ b/en_US/extensions/plugin-catalog/emqx-username-quota.md
@@ -224,7 +224,9 @@ Tarballs for each EMQX release:
 
 | EMQX Version | Plugin Version | Package |
 |---|---|---|
-| 6.2.0 | 1.2.0 | [emqx_username_quota-1.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.tar.gz) |
-| 6.2.1 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.tar.gz) |
+| 6.2.0 | 1.2.0 | [emqx_username_quota-1.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.sha256)) |
+| 6.2.1 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.sha256)) |
+| 6.2.2 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_username_quota-1.2.2.sha256)) |
+| 6.2.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_username_quota-1.2.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/refresh-plugin-download-links.py
+++ b/refresh-plugin-download-links.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """Refresh plugin download-link tables in plugin-catalog docs.
 
-Starting with EMQX 5.10 (enterprise) and 6.2 (unified), plugins live in
+Starting with EMQX 5.10 (enterprise) and 6.0.3 (unified), plugins live in
 the emqx.git monorepo under `plugins/<name>/` and each has a `VERSION`
 file. For every stable release tag in the chosen series, the CI
-publishes a tarball at:
+publishes a tarball and its sha256 digest, served from the emqx.com
+download CDN:
 
-    https://packages.emqx.io/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.tar.gz
+    https://www.emqx.com/downloads/emqx-plugins/<tag>/<plugin>-<plugin-ver>.sha256
 
 where `<tag>` is the literal git tag — bare semver for 6.x (e.g. `6.2.0`)
-and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`).
+and `e`-prefixed for 5.x enterprise (e.g. `e5.10.4`). Note the digest
+file replaces the `.tar.gz` extension rather than appending to it.
 
 This script walks the stable tags of one series (e.g. 5.10 or 6.2),
 reads each plugin's VERSION file, and regenerates a "Download" table
@@ -55,8 +58,14 @@ from pathlib import Path
 from typing import Iterable
 
 DEFAULT_EMQX_REMOTE = "https://github.com/emqx/emqx.git"
+# The emqx.com download CDN (matches scripts/rel/print-download-links.py in
+# emqx.git). Steering users to www.emqx.com/downloads rather than the S3
+# bucket keeps download statistics visible.
 PACKAGE_URL_TEMPLATE = (
-    "https://packages.emqx.io/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.tar.gz"
+)
+SHA256_URL_TEMPLATE = (
+    "https://www.emqx.com/downloads/emqx-plugins/{tag}/{plugin}-{plugin_ver}.sha256"
 )
 
 # Stable release tags. Two conventions are in use:
@@ -262,23 +271,18 @@ def render_section(
     )
     lines.append("|---|---|---|")
     for tag, plugin_ver in entries:
-        url = PACKAGE_URL_TEMPLATE.format(
-            tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
-        )
-        filename = f"{plugin}-{plugin_ver}.tar.gz"
-        lines.append(
-            f"| {tag.display_version} | {plugin_ver} | [{filename}]({url}) |"
-        )
+        lines.append(render_data_row(plugin, tag, plugin_ver))
     lines.append("")
     lines.append(END_MARKER)
     return "\n".join(lines)
 
 
 # A markdown table row whose first column is an EMQX version like "5.10.4"
-# or "6.2.0" and third column is the package link `[name](url)`. The middle
+# or "6.2.0" and third column starts with the package link `[name](url)`,
+# optionally followed by more links (e.g. the sha256 digest). The middle
 # column (plugin version) is matched loosely.
 DATA_ROW_RE = re.compile(
-    r"^\|\s*(?P<display_version>\d+\.\d+\.\d+)\s*\|\s*[^|]+\|\s*\[[^\]]+\]\([^)]+\)\s*\|\s*$"
+    r"^\|\s*(?P<display_version>\d+\.\d+\.\d+)\s*\|\s*[^|]+\|\s*\[[^\]]+\]\([^)]+\)[^|]*\|\s*$"
 )
 SEPARATOR_ROW_RE = re.compile(r"^\|\s*-+\s*(?:\|\s*-+\s*)+\|\s*$")
 
@@ -296,8 +300,14 @@ def render_data_row(plugin: str, tag: ReleaseTag, plugin_ver: str) -> str:
     url = PACKAGE_URL_TEMPLATE.format(
         tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
     )
+    sha256_url = SHA256_URL_TEMPLATE.format(
+        tag=tag.raw, plugin=plugin, plugin_ver=plugin_ver
+    )
     filename = f"{plugin}-{plugin_ver}.tar.gz"
-    return f"| {tag.display_version} | {plugin_ver} | [{filename}]({url}) |"
+    return (
+        f"| {tag.display_version} | {plugin_ver} | "
+        f"[{filename}]({url}) ([sha256]({sha256_url})) |"
+    )
 
 
 def append_new_rows(
@@ -366,14 +376,13 @@ def update_catalog_files(
         for locale in locales:
             path = docs_root / locale / subpath / fname
             existed = path.exists()
-            new_section = render_section(locale, plugin, entries)
             if existed:
                 original = path.read_text(encoding="utf-8")
             elif locale in bootstrap_locales and plugin in readmes:
                 original = readmes[plugin].rstrip() + "\n"
             else:
                 continue
-            updated = splice_section(original, new_section)
+            updated = splice_section(original, locale, plugin, entries)
             if existed and updated == original:
                 print(f"unchanged: {path.relative_to(docs_root)}", file=sys.stderr)
                 continue
@@ -467,6 +476,14 @@ def main() -> int:
 
     series = resolve_series(args.series, docs_root)
     subpath = catalog_subpath(series)
+    if not any((docs_root / loc / subpath).is_dir() for loc in present_locales):
+        # This branch still publishes the flat (unversioned) catalog pages;
+        # the version-scoped subdir arrives with its own restructuring.
+        print(
+            f"note: {subpath} not found; using flat catalog dir {CATALOG_BASE}",
+            file=sys.stderr,
+        )
+        subpath = CATALOG_BASE
     print(
         f"Targeting release series {series[0]}.{series[1]} "
         f"(catalog dir: {subpath})",

--- a/zh_CN/extensions/plugin-catalog/emqx-bridge-mqtt-dq.md
+++ b/zh_CN/extensions/plugin-catalog/emqx-bridge-mqtt-dq.md
@@ -514,7 +514,9 @@ curl -u admin:public \
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.2.0 | 0.5.1 | [emqx_bridge_mqtt_dq-0.5.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.tar.gz) |
-| 6.2.1 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.tar.gz) |
+| 6.2.0 | 0.5.1 | [emqx_bridge_mqtt_dq-0.5.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_bridge_mqtt_dq-0.5.1.sha256)) |
+| 6.2.1 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.2.2 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
+| 6.2.3 | 0.5.2 | [emqx_bridge_mqtt_dq-0.5.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_bridge_mqtt_dq-0.5.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_bridge_mqtt_dq-0.5.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/emqx-unsgov.md
+++ b/zh_CN/extensions/plugin-catalog/emqx-unsgov.md
@@ -224,7 +224,9 @@ UNS Governance 会同时校验主题结构以及（可选的）负载模式。
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.2.0 | 0.1.2 | [emqx_unsgov-0.1.2.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.tar.gz) |
-| 6.2.1 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.tar.gz) |
+| 6.2.0 | 0.1.2 | [emqx_unsgov-0.1.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_unsgov-0.1.2.sha256)) |
+| 6.2.1 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_unsgov-0.1.3.sha256)) |
+| 6.2.2 | 0.1.3 | [emqx_unsgov-0.1.3.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_unsgov-0.1.3.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_unsgov-0.1.3.sha256)) |
+| 6.2.3 | 0.1.4 | [emqx_unsgov-0.1.4.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_unsgov-0.1.4.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_unsgov-0.1.4.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->

--- a/zh_CN/extensions/plugin-catalog/emqx-username-quota.md
+++ b/zh_CN/extensions/plugin-catalog/emqx-username-quota.md
@@ -221,7 +221,9 @@
 
 | EMQX 版本 | 插件版本 | 安装包 |
 |---|---|---|
-| 6.2.0 | 1.2.0 | [emqx_username_quota-1.2.0.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.tar.gz) |
-| 6.2.1 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://packages.emqx.io/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.tar.gz) |
+| 6.2.0 | 1.2.0 | [emqx_username_quota-1.2.0.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.0/emqx_username_quota-1.2.0.sha256)) |
+| 6.2.1 | 1.2.1 | [emqx_username_quota-1.2.1.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.1/emqx_username_quota-1.2.1.sha256)) |
+| 6.2.2 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.2/emqx_username_quota-1.2.2.sha256)) |
+| 6.2.3 | 1.2.2 | [emqx_username_quota-1.2.2.tar.gz](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_username_quota-1.2.2.tar.gz) ([sha256](https://www.emqx.com/downloads/emqx-plugins/6.2.3/emqx_username_quota-1.2.2.sha256)) |
 
 <!-- PLUGIN-DOWNLOADS:END -->


### PR DESCRIPTION
Port of #3814 to release-6.2. Align the plugin download-link generator with `scripts/rel/print-download-links.py` in emqx.git:

- Serve plugin packages from the emqx.com download CDN (`https://www.emqx.com/downloads/emqx-plugins/...`) instead of the S3 bucket (`https://packages.emqx.io/...`), keeping download statistics visible.
- Add a `sha256` link next to each tarball. The digest file replaces the `.tar.gz` extension (`<name>-<vsn>.sha256`).

Branch-specific fixes that surfaced while porting:

- `update_catalog_files` still called `splice_section()` with its old signature, so the script did not run at all on this branch. Fixed, which is also why the published tables were stale — the missing 6.2.2 and 6.2.3 rows are now appended.
- release-6.2 still publishes the flat catalog pages (`extensions/plugin-catalog/*.md`); the script now falls back to the flat dir when the version-scoped subdir does not exist. The unpublished `6.0/` and `6.1/` orphan dirs are left untouched; they receive their CDN updates through the regular sync merges (#3815, #3816).
- `DATA_ROW_RE` now tolerates the sha256 suffix so the append-only splice stays idempotent.

All CDN URLs verified to return HTTP 200 after the redirect, except the three `6.2.0/*.sha256` digests which are missing from the bucket (tarballs are there; digests exist from 6.2.1 onward). Same backfill situation as `6.1.1/emqx_username_quota-1.0.0.sha256` noted in #3816.