### PR TITLE
docs: document the etc/emqx.env boot-time environment file

### DIFF
--- a/en_US/configuration/configuration.md
+++ b/en_US/configuration/configuration.md
@@ -183,7 +183,7 @@ Most `EMQX_`-prefixed environment variables override `emqx.conf` settings, follo
 - `EMQX_FEATURES`: Selects the set of applications the node boots, for example `FULL` or `ESSENTIAL`.
 - `EMQX_SECURITY_PROFILE`: Selects the node-wide security profile, `legacy` or `hardened`.
 
-Starting from EMQX 6.3.0, the `emqx` command sources the environment file `etc/emqx.env` (`/etc/emqx/emqx.env` on rpm and deb installs) on every invocation: service start, foreground start, `emqx ctl`, and so on. Use this file to set boot-time environment variables on package installs, instead of editing the systemd unit.
+Starting from EMQX 6.3.0, the `emqx` command loads environment variables from `etc/emqx.env` whenever it runs, including during a service start, a foreground start, and `emqx ctl`. On RPM and DEB installations, the file is located at `/etc/emqx/emqx.env`. Use this file to set boot-time environment variables instead of editing the systemd unit.
 
 - Values set in the file override variables inherited from the environment.
 - Package upgrades keep your edits to the file.

--- a/en_US/configuration/configuration.md
+++ b/en_US/configuration/configuration.md
@@ -175,6 +175,21 @@ When a known root path is set with an unknown field name, EMQX will output a `wa
 Starting from EMQX 6.3.0, `EMQX_FEATURES` is a special startup environment variable for [feature gates](../deploy/feature-gates.md). It does not map to a HOCON configuration path, is not stored in `cluster.hocon`, and is resolved only when EMQX starts.
 :::
 
+
+### Boot-Time Environment Variables
+
+Most `EMQX_`-prefixed environment variables override `emqx.conf` settings, following the conversion rules above. A few variables configure EMQX itself before the configuration files are parsed, so they have no `emqx.conf` equivalent:
+
+- `EMQX_FEATURES`: Selects the set of applications the node boots, for example `FULL` or `ESSENTIAL`.
+- `EMQX_SECURITY_PROFILE`: Selects the node-wide security profile, `legacy` or `hardened`.
+
+Starting from EMQX 6.3.0, the `emqx` command sources the environment file `etc/emqx.env` (`/etc/emqx/emqx.env` on rpm and deb installs) on every invocation: service start, foreground start, `emqx ctl`, and so on. Use this file to set boot-time environment variables on package installs, instead of editing the systemd unit.
+
+- Values set in the file override variables inherited from the environment.
+- Package upgrades keep your edits to the file.
+- The shipped file lists the boot-time variables commented out at their defaults, in the `KEY="${KEY:-default}"` form: uncommented as shipped, a line keeps a value already set in the environment and falls back to the default otherwise. Write `KEY=value` to force a value.
+- Regular `EMQX_`-prefixed overrides, for example `EMQX_NODE__COOKIE`, can also be set in the file.
+
 ## Config Override Rules
 
 In EMQX, configuration values are applied hierarchically, with the following override rules:

--- a/en_US/configuration/configuration.md
+++ b/en_US/configuration/configuration.md
@@ -187,7 +187,8 @@ Starting from EMQX 6.3.0, the `emqx` command sources the environment file `etc/e
 
 - Values set in the file override variables inherited from the environment.
 - Package upgrades keep your edits to the file.
-- The shipped file lists the boot-time variables commented out at their defaults, in the `KEY="${KEY:-default}"` form: uncommented as shipped, a line keeps a value already set in the environment and falls back to the default otherwise. Write `KEY=value` to force a value.
+- The shipped file lists boot-time variables as commented lines, for example, `#KEY="${KEY:-default}"`. If you uncomment a line without changing the expression, it keeps a nonempty environment value or uses the default when the variable is unset or empty. To override an existing value, replace the expression with `KEY=value`.
+- Restart the EMQX node after changing a boot-time environment variable.
 - Regular `EMQX_`-prefixed overrides, for example `EMQX_NODE__COOKIE`, can also be set in the file.
 
 ## Config Override Rules

--- a/en_US/deploy/dirs.md
+++ b/en_US/deploy/dirs.md
@@ -29,6 +29,7 @@ Files in this directory are read-only.
 * `base.hocon`: The bootstrapping config file for EMQX for configs with lowest override priority
 * `emqx.conf`: The bootstrapping config file for EMQX for configs with highest override priority
 * `vm.args`: The boot arguments for Erlang virtual machine
+* `emqx.env`: Boot-time environment variables, sourced by the `emqx` command on every invocation (since EMQX 6.3.0)
 * `certs/`: X.509 keys are certificate files for EMQX SSL listeners or SSL clients when
   integrating with external systems. e.g., HTTPS client for webhooks
 

--- a/en_US/deploy/install-debian-ce.md
+++ b/en_US/deploy/install-debian-ce.md
@@ -50,7 +50,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 
 #### Uninstall EMQX

--- a/en_US/deploy/install-debian-ce.md
+++ b/en_US/deploy/install-debian-ce.md
@@ -49,6 +49,10 @@ Start EMQX as a systemd service, run:
 sudo systemctl start emqx
 ```
 
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
+
 #### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-debian.md
+++ b/en_US/deploy/install-debian.md
@@ -25,6 +25,10 @@ Start EMQX as a systemd service, run:
 sudo systemctl start emqx
 ```
 
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
+
 ### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-debian.md
+++ b/en_US/deploy/install-debian.md
@@ -26,7 +26,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 
 ### Uninstall EMQX

--- a/en_US/deploy/install-rhel-ce.md
+++ b/en_US/deploy/install-rhel-ce.md
@@ -59,7 +59,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 
 ### Uninstall EMQX

--- a/en_US/deploy/install-rhel-ce.md
+++ b/en_US/deploy/install-rhel-ce.md
@@ -58,6 +58,10 @@ Start EMQX as a systemd service.
 sudo systemctl start emqx
 ```
 
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
+
 ### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-rhel.md
+++ b/en_US/deploy/install-rhel.md
@@ -25,7 +25,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 ### Uninstall EMQX
 

--- a/en_US/deploy/install-rhel.md
+++ b/en_US/deploy/install-rhel.md
@@ -23,6 +23,10 @@ Start EMQX as a systemd service.
 ```bash
 sudo systemctl start emqx
 ```
+
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
 ### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-ubuntu-ce.md
+++ b/en_US/deploy/install-ubuntu-ce.md
@@ -51,7 +51,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 
 #### Uninstall EMQX

--- a/en_US/deploy/install-ubuntu-ce.md
+++ b/en_US/deploy/install-ubuntu-ce.md
@@ -50,6 +50,10 @@ Start EMQX as a systemctl service.
 sudo systemctl start emqx
 ```
 
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
+
 #### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-ubuntu.md
+++ b/en_US/deploy/install-ubuntu.md
@@ -47,6 +47,10 @@ Start EMQX as a systemd service.
 sudo systemctl start emqx
 ```
 
+::: tip
+Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+:::
+
 #### Uninstall EMQX
 
 To uninstall EMQX, run:

--- a/en_US/deploy/install-ubuntu.md
+++ b/en_US/deploy/install-ubuntu.md
@@ -48,7 +48,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-Starting from EMQX 6.3.0, boot-time environment variables such as `EMQX_SECURITY_PROFILE` can be set in `/etc/emqx/emqx.env`. The `emqx` command sources this file on every invocation, and package upgrades keep your edits. See [Environment Variables](../configuration/configuration.md#environment-variables).
+Starting from EMQX 6.3.0, set boot-time environment variables such as `EMQX_SECURITY_PROFILE` in `/etc/emqx/emqx.env`. The `emqx` command loads this file whenever it runs, including during a service start, a foreground start, and `emqx ctl`. Package upgrades preserve your changes to this file. Restart the EMQX node to apply changes to boot-time environment variables. See [Boot-Time Environment Variables](../configuration/configuration.md#boot-time-environment-variables).
 :::
 
 #### Uninstall EMQX

--- a/zh_CN/configuration/configuration.md
+++ b/zh_CN/configuration/configuration.md
@@ -178,6 +178,21 @@ listeners.ssl.default {
 从 EMQX 6.3.0 开始，`EMQX_FEATURES` 是用于[功能门控](../deploy/feature-gates.md)的特殊启动环境变量。它不会映射到 HOCON 配置路径，不会写入 `cluster.hocon`，并且只在 EMQX 启动时解析。
 :::
 
+
+### 启动期环境变量
+
+大多数 `EMQX_` 前缀的环境变量按上述转换规则覆盖 `emqx.conf` 中的配置项。少数变量在配置文件解析之前就被读取，用于配置 EMQX 自身，因此没有对应的 `emqx.conf` 配置项：
+
+- `EMQX_FEATURES`：选择节点启动的应用集合，例如 `FULL` 或 `ESSENTIAL`。
+- `EMQX_SECURITY_PROFILE`：选择节点级安全配置档案，`legacy` 或 `hardened`。
+
+从 EMQX 6.3.0 开始，`emqx` 命令在每次执行时（启动服务、前台启动、`emqx ctl` 等）都会加载环境文件 `etc/emqx.env`（rpm 和 deb 安装为 `/etc/emqx/emqx.env`）。在软件包安装环境中，请使用该文件设置启动期环境变量，而不要修改 systemd 单元文件。
+
+- 文件中设置的值会覆盖从环境中继承的变量。
+- 软件包升级会保留您对该文件的修改。
+- 文件默认以注释形式列出启动期环境变量及其默认值，采用 `KEY="${KEY:-default}"` 形式：直接取消注释时，已在环境中设置的值保持不变，否则回退到默认值。写成 `KEY=value` 可强制指定值。
+- 普通的 `EMQX_` 前缀覆盖变量（例如 `EMQX_NODE__COOKIE`）也可以设置在该文件中。
+
 ## 配置覆盖规则
 
 HOCON 的值是分层覆盖的，最简单的规则如下：

--- a/zh_CN/configuration/configuration.md
+++ b/zh_CN/configuration/configuration.md
@@ -186,7 +186,7 @@ listeners.ssl.default {
 - `EMQX_FEATURES`：选择节点启动的应用集合，例如 `FULL` 或 `ESSENTIAL`。
 - `EMQX_SECURITY_PROFILE`：选择节点级安全配置方案（Security Profile），可选值为 `legacy` 或 `hardened`。
 
-从 EMQX 6.3.0 开始，`emqx` 命令在每次执行时（启动服务、前台启动、`emqx ctl` 等）都会加载环境文件 `etc/emqx.env`（rpm 和 deb 安装为 `/etc/emqx/emqx.env`）。在软件包安装环境中，请使用该文件设置启动期环境变量，而不要修改 systemd 单元文件。
+从 EMQX 6.3.0 开始，`emqx` 命令每次执行时都会从 `etc/emqx.env` 加载环境变量，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。对于 RPM 和 DEB 安装，该文件位于 `/etc/emqx/emqx.env`。请使用该文件设置启动期环境变量，而不要修改 systemd 单元文件。
 
 - 文件中设置的值会覆盖从环境中继承的变量。
 - 软件包升级会保留您对该文件的修改。

--- a/zh_CN/configuration/configuration.md
+++ b/zh_CN/configuration/configuration.md
@@ -184,13 +184,14 @@ listeners.ssl.default {
 大多数 `EMQX_` 前缀的环境变量按上述转换规则覆盖 `emqx.conf` 中的配置项。少数变量在配置文件解析之前就被读取，用于配置 EMQX 自身，因此没有对应的 `emqx.conf` 配置项：
 
 - `EMQX_FEATURES`：选择节点启动的应用集合，例如 `FULL` 或 `ESSENTIAL`。
-- `EMQX_SECURITY_PROFILE`：选择节点级安全配置档案，`legacy` 或 `hardened`。
+- `EMQX_SECURITY_PROFILE`：选择节点级安全配置方案（Security Profile），可选值为 `legacy` 或 `hardened`。
 
 从 EMQX 6.3.0 开始，`emqx` 命令在每次执行时（启动服务、前台启动、`emqx ctl` 等）都会加载环境文件 `etc/emqx.env`（rpm 和 deb 安装为 `/etc/emqx/emqx.env`）。在软件包安装环境中，请使用该文件设置启动期环境变量，而不要修改 systemd 单元文件。
 
 - 文件中设置的值会覆盖从环境中继承的变量。
 - 软件包升级会保留您对该文件的修改。
-- 文件默认以注释形式列出启动期环境变量及其默认值，采用 `KEY="${KEY:-default}"` 形式：直接取消注释时，已在环境中设置的值保持不变，否则回退到默认值。写成 `KEY=value` 可强制指定值。
+- EMQX 随附的文件以注释行列出启动期环境变量，例如 `#KEY="${KEY:-default}"`。如果直接取消注释而不修改表达式，文件会保留环境中已有的非空值；如果变量未设置或值为空，则使用默认值。如需覆盖已有值，请将表达式改为 `KEY=value`。
+- 修改启动期环境变量后，需要重启 EMQX 节点。
 - 普通的 `EMQX_` 前缀覆盖变量（例如 `EMQX_NODE__COOKIE`）也可以设置在该文件中。
 
 ## 配置覆盖规则

--- a/zh_CN/deploy/install-debian-ce.md
+++ b/zh_CN/deploy/install-debian-ce.md
@@ -50,7 +50,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 #### 卸载 EMQX

--- a/zh_CN/deploy/install-debian-ce.md
+++ b/zh_CN/deploy/install-debian-ce.md
@@ -49,6 +49,10 @@ systemctl 启动：
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 #### 卸载 EMQX
 
 服务完成后，可通过如下命令卸载 EMQX：

--- a/zh_CN/deploy/install-debian.md
+++ b/zh_CN/deploy/install-debian.md
@@ -24,6 +24,10 @@ systemctl 启动：
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 ### 卸载 EMQX
 
 安装完成后，可通过如下命令卸载 EMQX：

--- a/zh_CN/deploy/install-debian.md
+++ b/zh_CN/deploy/install-debian.md
@@ -25,7 +25,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 ### 卸载 EMQX

--- a/zh_CN/deploy/install-rhel-ce.md
+++ b/zh_CN/deploy/install-rhel-ce.md
@@ -55,6 +55,10 @@ EMQX 同时支持通过下载 rpm 安装包进行安装。本节以 CentOS 8 系
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 ### 卸载 EMQX
 
 服务完成后，可通过如下命令卸载 EMQX：

--- a/zh_CN/deploy/install-rhel-ce.md
+++ b/zh_CN/deploy/install-rhel-ce.md
@@ -56,7 +56,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 ### 卸载 EMQX

--- a/zh_CN/deploy/install-rhel.md
+++ b/zh_CN/deploy/install-rhel.md
@@ -25,7 +25,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 ### 卸载 EMQX

--- a/zh_CN/deploy/install-rhel.md
+++ b/zh_CN/deploy/install-rhel.md
@@ -24,6 +24,10 @@
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 ### 卸载 EMQX
 
 安装完成后，可通过如下命令卸载 EMQX：

--- a/zh_CN/deploy/install-ubuntu-ce.md
+++ b/zh_CN/deploy/install-ubuntu-ce.md
@@ -51,7 +51,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 #### 卸载 EMQX

--- a/zh_CN/deploy/install-ubuntu-ce.md
+++ b/zh_CN/deploy/install-ubuntu-ce.md
@@ -50,6 +50,10 @@ EMQX 支持通过 deb 包或 tar.gz 包进行安装。如希望在其他支持�
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 #### 卸载 EMQX
 
 服务完成后，可通过如下命令卸载 EMQX：

--- a/zh_CN/deploy/install-ubuntu.md
+++ b/zh_CN/deploy/install-ubuntu.md
@@ -48,7 +48,7 @@ sudo systemctl start emqx
 ```
 
 ::: tip
-从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+从 EMQX 6.3.0 开始，可在 `/etc/emqx/emqx.env` 中设置启动期环境变量，例如 `EMQX_SECURITY_PROFILE`。`emqx` 命令每次执行时都会加载该文件，包括以服务方式启动、前台启动以及运行 `emqx ctl` 时。软件包升级会保留对该文件的修改。修改启动期环境变量后，重启 EMQX 节点以使更改生效。参见[启动期环境变量](../configuration/configuration.md#启动期环境变量)。
 :::
 
 #### 卸载 EMQX

--- a/zh_CN/deploy/install-ubuntu.md
+++ b/zh_CN/deploy/install-ubuntu.md
@@ -47,6 +47,10 @@ EMQX 支持通过 `.deb` 软件包或 `.tar.gz` 压缩包进行安装。如希�
 sudo systemctl start emqx
 ```
 
+::: tip
+从 EMQX 6.3.0 开始，可以在 `/etc/emqx/emqx.env` 中设置启动期环境变量（例如 `EMQX_SECURITY_PROFILE`）。`emqx` 命令每次执行时都会加载该文件，软件包升级会保留您的修改。参见[环境变量](../configuration/configuration.md#环境变量)。
+:::
+
 #### 卸载 EMQX
 
 安装完成后，可通过如下命令卸载 EMQX：


### PR DESCRIPTION
Documents the boot-time environment file shipped by emqx/emqx#18451 (EMQX 6.3.0).

- `configuration.md` (en/zh): new **Boot-Time Environment Variables** subsection under **Environment Variables** — `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` have no `emqx.conf` equivalent; the `emqx` command sources `etc/emqx.env` (`/etc/emqx/emqx.env` on rpm/deb) on every invocation; file values override the inherited environment; package upgrades keep edits; the shipped defaults use the `KEY="${KEY:-default}"` form.
- `deploy/dirs.md`: `emqx.env` added to the `etc` file list.
- Install guides (ubuntu/debian/rhel, enterprise and CE, en/zh): a tip after the systemd start step pointing at `/etc/emqx/emqx.env` instead of unit edits.

Related: emqx/emqx#18471 (node_dump collects the file with secrets obfuscated).
