### PR TITLE
docs: clarify node name host part must be FQDN or IP

### DIFF
--- a/en_US/deploy/install-docker.md
+++ b/en_US/deploy/install-docker.md
@@ -52,7 +52,7 @@ This section will introduce how to use the Docker image to install the latest ve
 
    To configure the node name for a single node deployment, use the `EMQX_NODE_NAME` environment variable with the format `emqx@<host>`. You should also set the container hostname to match, as shown in the example above.
 
-   **Note:** The `<host>` part must be a fully qualified domain name (FQDN, a name with dots, such as `node1.emqx.com`) or an IP address. EMQX runs the Erlang node with long names, so a short (undotted) hostname such as `node1` does not work.
+   **Note:** The `<host>` part must be an IP address or a fully qualified domain name (FQDN), such as `node1.emqx.com`. EMQX runs its Erlang node in long-name mode, so you cannot use a short hostname without dots, such as `node1`.
 
 ## Use Docker Compose to Build an EMQX Cluster
 

--- a/en_US/deploy/install-docker.md
+++ b/en_US/deploy/install-docker.md
@@ -50,9 +50,9 @@ This section will introduce how to use the Docker image to install the latest ve
 
 3. EMQX employs the `data/mnesia/<node_name>` directory for data storage. It's crucial to choose a stable identifier, such as a Fully Qualified Domain Name (FQDN), to serve as the node name. This practice avoids data loss caused by node name changes.
 
-   To configure the node name for a single node deployment, use the `EMQX_NODE_NAME` environment variable with the format `emqx@hostname`. You should also set the container hostname to match, as shown in the example above.
+   To configure the node name for a single node deployment, use the `EMQX_NODE_NAME` environment variable with the format `emqx@<host>`. You should also set the container hostname to match, as shown in the example above.
 
-   **Note:** The node name must follow the format `emqx@<hostname>` where `<hostname>` should match the container's hostname or a stable FQDN.
+   **Note:** The `<host>` part must be a fully qualified domain name (FQDN, a name with dots, such as `node1.emqx.com`) or an IP address. EMQX runs the Erlang node with long names, so a short (undotted) hostname such as `node1` does not work.
 
 ## Use Docker Compose to Build an EMQX Cluster
 

--- a/en_US/faq/deployment.md
+++ b/en_US/faq/deployment.md
@@ -303,7 +303,7 @@ hostname: docker.emqx.com
       - EMQX_HOST=docker.emqx.com
 ```
 
-Since EMQX stores data in the directory `data/mnesia/<node name>`, it's important to use a stable identifier as the node name to avoid potential data loss if the node name changes: use a fully qualified domain name (FQDN, a name with dots) rather than a container IP address that may change. A short (undotted) hostname does not work, because EMQX runs the Erlang node with long names.
+Because EMQX stores data in `data/mnesia/<node name>`, use a stable node name to avoid data loss if the node name changes. Use an FQDN rather than a container IP address, which may change. EMQX runs its Erlang node in long-name mode, so you cannot use a short hostname without dots.
 
 To make this easier, consider using the [EMQX Docker Compose Generator](https://docker.emqx.dev/) to create a production-ready `docker-compose.yml` file.
 

--- a/en_US/faq/deployment.md
+++ b/en_US/faq/deployment.md
@@ -303,7 +303,7 @@ hostname: docker.emqx.com
       - EMQX_HOST=docker.emqx.com
 ```
 
-Since EMQX stores data in the directory `data/mnesia/<node name>`, it's important to use a fixed identifier like the hostname or FQDN (instead of an IP address) as the node name to avoid potential data loss if the node name changes.
+Since EMQX stores data in the directory `data/mnesia/<node name>`, it's important to use a stable identifier as the node name to avoid potential data loss if the node name changes: use a fully qualified domain name (FQDN, a name with dots) rather than a container IP address that may change. A short (undotted) hostname does not work, because EMQX runs the Erlang node with long names.
 
 To make this easier, consider using the [EMQX Docker Compose Generator](https://docker.emqx.dev/) to create a production-ready `docker-compose.yml` file.
 

--- a/zh_CN/deploy/install-docker.md
+++ b/zh_CN/deploy/install-docker.md
@@ -49,7 +49,7 @@
 
    对于单节点部署，需要使用 `EMQX_NODE_NAME` 环境变量配置节点名，格式为 `emqx@<host>`。您还应该设置容器主机名以保持一致，如上面示例所示。
 
-   **注意：** `<host>` 部分必须是完全限定域名（FQDN，即带点的域名，例如 `node1.emqx.com`）或 IP 地址。EMQX 的 Erlang 节点以长名称（long name）模式运行，因此不支持不带点的短主机名（例如 `node1`）。
+   **注意：** `<host>` 部分必须是 IP 地址或完全限定域名（FQDN），例如 `node1.emqx.com`。EMQX 的 Erlang 节点以长节点名模式运行，因此不能使用不含点号的短主机名，例如 `node1`。
 
 ## 通过 Docker Compose 构建 EMQX 集群
 

--- a/zh_CN/deploy/install-docker.md
+++ b/zh_CN/deploy/install-docker.md
@@ -47,9 +47,9 @@
 
 3. 由于 EMQX 使用 `data/mnesia/<节点名>` 作为数据存储目录，请使用 FQDN 等固定的信息作为节点名，避免因为节点名称变动导致数据丢失。
 
-   对于单节点部署，需要使用 `EMQX_NODE_NAME` 环境变量配置节点名，格式为 `emqx@hostname`。您还应该设置容器主机名以保持一致，如上面示例所示。
+   对于单节点部署，需要使用 `EMQX_NODE_NAME` 环境变量配置节点名，格式为 `emqx@<host>`。您还应该设置容器主机名以保持一致，如上面示例所示。
 
-   **注意：** 节点名必须遵循 `emqx@<hostname>` 格式，其中 `<hostname>` 应该与容器的主机名或稳定的 FQDN 匹配。
+   **注意：** `<host>` 部分必须是完全限定域名（FQDN，即带点的域名，例如 `node1.emqx.com`）或 IP 地址。EMQX 的 Erlang 节点以长名称（long name）模式运行，因此不支持不带点的短主机名（例如 `node1`）。
 
 ## 通过 Docker Compose 构建 EMQX 集群
 

--- a/zh_CN/faq/deployment.md
+++ b/zh_CN/faq/deployment.md
@@ -271,6 +271,6 @@ hostname: docker.emqx.com
       - EMQX_HOST=docker.emqx.com
 ```
 
-由于 EMQX 使用 `data/mnesia/<节点名>` 作为数据存储目录，使用 hostname 或者 FQDN 等固定的信息作为节点名（不推荐使用 IP），还可以避免因为节点名称变动导致数据丢失。 
+由于 EMQX 使用 `data/mnesia/<节点名>` 作为数据存储目录，应使用稳定的标识作为节点名，避免因节点名变动导致数据丢失：推荐使用完全限定域名（FQDN，即带点的域名），不推荐使用可能变化的容器 IP。EMQX 的 Erlang 节点以长名称（long name）模式运行，因此不支持不带点的短主机名。 
 
 推荐使用 [EMQX Docker Compose 一键生成器](https://docker.emqx.dev/) 一键生成生产就绪的 `docker-compose.yml` 文件。

--- a/zh_CN/faq/deployment.md
+++ b/zh_CN/faq/deployment.md
@@ -271,6 +271,6 @@ hostname: docker.emqx.com
       - EMQX_HOST=docker.emqx.com
 ```
 
-由于 EMQX 使用 `data/mnesia/<节点名>` 作为数据存储目录，应使用稳定的标识作为节点名，避免因节点名变动导致数据丢失：推荐使用完全限定域名（FQDN，即带点的域名），不推荐使用可能变化的容器 IP。EMQX 的 Erlang 节点以长名称（long name）模式运行，因此不支持不带点的短主机名。 
+由于 EMQX 使用 `data/mnesia/<节点名>` 作为数据存储目录，应使用稳定的节点名，避免节点名变动造成数据丢失。推荐使用完全限定域名（FQDN），不要使用可能变化的容器 IP。EMQX 的 Erlang 节点以长节点名模式运行，因此不能使用不含点号的短主机名。
 
 推荐使用 [EMQX Docker Compose 一键生成器](https://docker.emqx.dev/) 一键生成生产就绪的 `docker-compose.yml` 文件。


### PR DESCRIPTION
Same fix as #3825, for release-6.1. The docker install and deployment FAQ pages said the node name is `emqx@<hostname>` where `<hostname>` "should match the container's hostname or a stable FQDN". A bare (undotted) hostname reads as valid there, but EMQX always runs the Erlang node with long names when the name contains `@` (see `bin/emqx`), so a short hostname does not work.

Reworded in en_US and zh_CN:

- `deploy/install-docker.md`: the `<host>` part must be an FQDN (a name with dots, e.g. `node1.emqx.com`) or an IP address; short hostnames such as `node1` do not work.
- `faq/deployment.md`: the "use the hostname or FQDN" recommendation now says FQDN (not IP, not short hostname) with the same reasoning.